### PR TITLE
Add AWS resource tracer and pruner

### DIFF
--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -1,14 +1,15 @@
 """
 AWS Resource Pruner
 
-Reads JSON output from resource_tracer.py and terminates the listed EC2 instances.
+Reads JSON output from resource_tracer.py and deletes the listed resources.
+Supports EC2 instances and NAT gateways.
 
 Usage:
-    # Dry run (default) — shows what would be terminated
+    # Dry run (default) — shows what would be deleted
     python src/resource_tracer.py --scan --region us-east-1 --filter prunable --output json | \
         python src/resource_pruner.py --region us-east-1 -
 
-    # Actual termination
+    # Actual deletion
     python src/resource_pruner.py --region us-east-1 --dry-run false prunable.json
 """
 
@@ -20,7 +21,7 @@ import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
 
-BATCH_SIZE = 1000
+EC2_BATCH_SIZE = 1000
 
 
 def load_traces(input_file):
@@ -43,41 +44,41 @@ def load_traces(input_file):
     return traces
 
 
-def terminate_instances(ec2, traces, dry_run):
-    ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
-    skipped_type = len(traces) - len(ec2_traces)
-    if skipped_type:
-        print(f"Skipping {skipped_type} non-EC2 resources")
-
-    skip_states = {"terminated", "terminating"}
-    actionable = [t for t in ec2_traces if t.get("state", "") not in skip_states]
-    skipped_state = len(ec2_traces) - len(actionable)
-    if skipped_state:
-        print(f"Skipping {skipped_state} already terminated/terminating instances")
-
-    if not actionable:
-        print("No instances to terminate.")
-        return
-
+def _print_dry_run(actionable, resource_label):
     by_cluster = defaultdict(list)
     for t in actionable:
         key = t.get("cluster_name") or "Unassociated"
         by_cluster[key].append(t)
 
+    print(f"\n=== DRY RUN — {len(actionable)} {resource_label} would be deleted ===\n")
+    for cluster, resources in sorted(by_cluster.items()):
+        cluster_type = resources[0].get("cluster_type", "unknown")
+        prunability = resources[0].get("prunability", "")
+        label = f"{cluster} ({cluster_type})"
+        if prunability:
+            label += f" [{prunability.upper()}]"
+        print(f"  {label}")
+        for t in resources:
+            extra = f"  {t.get('instance_type', '')}" if t.get("instance_type") else ""
+            print(f"    {t['resource_id']}{extra}  {t.get('state', '')}")
+        print()
+    print(f"Total: {len(actionable)} {resource_label} across {len(by_cluster)} clusters")
+    print("Run with --dry-run false to delete.")
+
+
+def terminate_instances(ec2, traces, dry_run):
+    skip_states = {"terminated", "terminating"}
+    actionable = [t for t in traces if t.get("state", "") not in skip_states]
+    skipped = len(traces) - len(actionable)
+    if skipped:
+        print(f"Skipping {skipped} already terminated/terminating instances")
+
+    if not actionable:
+        print("No EC2 instances to terminate.")
+        return
+
     if dry_run:
-        print(f"\n=== DRY RUN — {len(actionable)} instances would be terminated ===\n")
-        for cluster, instances in sorted(by_cluster.items()):
-            cluster_type = instances[0].get("cluster_type", "unknown")
-            prunability = instances[0].get("prunability", "")
-            label = f"{cluster} ({cluster_type})"
-            if prunability:
-                label += f" [{prunability.upper()}]"
-            print(f"  {label}")
-            for t in instances:
-                print(f"    {t['resource_id']}  {t.get('instance_type', '')}  {t.get('state', '')}")
-            print()
-        print(f"Total: {len(actionable)} instances across {len(by_cluster)} clusters")
-        print("Run with --dry-run false to terminate.")
+        _print_dry_run(actionable, "instances")
         return
 
     print(f"\n=== TERMINATING {len(actionable)} instances ===\n")
@@ -85,8 +86,8 @@ def terminate_instances(ec2, traces, dry_run):
     success = 0
     failed = []
 
-    for i in range(0, len(instance_ids), BATCH_SIZE):
-        batch = instance_ids[i : i + BATCH_SIZE]
+    for i in range(0, len(instance_ids), EC2_BATCH_SIZE):
+        batch = instance_ids[i : i + EC2_BATCH_SIZE]
         print(f"Terminating batch of {len(batch)} instances...")
         for iid in batch:
             print(f"  {iid}")
@@ -116,9 +117,45 @@ def terminate_instances(ec2, traces, dry_run):
             print(f"  {iid}")
 
 
+def delete_nat_gateways(ec2, traces, dry_run):
+    skip_states = {"deleted", "deleting"}
+    actionable = [t for t in traces if t.get("state", "") not in skip_states]
+    skipped = len(traces) - len(actionable)
+    if skipped:
+        print(f"Skipping {skipped} already deleted/deleting NAT gateways")
+
+    if not actionable:
+        print("No NAT gateways to delete.")
+        return
+
+    if dry_run:
+        _print_dry_run(actionable, "NAT gateways")
+        return
+
+    print(f"\n=== DELETING {len(actionable)} NAT gateways ===\n")
+    success = 0
+    failed = []
+
+    for t in actionable:
+        nat_id = t["resource_id"]
+        print(f"  Deleting {nat_id}...")
+        try:
+            ec2.delete_nat_gateway(NatGatewayId=nat_id)
+            success += 1
+        except ClientError as e:
+            print(f"    Error: {e}")
+            failed.append(nat_id)
+
+    print(f"\nResult: {success} deleted, {len(failed)} failed")
+    if failed:
+        print("Failed NAT gateway IDs:")
+        for nid in failed:
+            print(f"  {nid}")
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="AWS Resource Pruner — terminates EC2 instances from resource_tracer.py JSON output"
+        description="AWS Resource Pruner — deletes resources from resource_tracer.py JSON output"
     )
     parser.add_argument(
         "input_file",
@@ -145,7 +182,7 @@ def main():
     if dry_run:
         print("Mode: DRY RUN")
     else:
-        print("Mode: LIVE — instances will be terminated")
+        print("Mode: LIVE — resources will be deleted")
     print(f"Region: {args.region}\n")
 
     try:
@@ -156,7 +193,17 @@ def main():
 
     traces = load_traces(args.input_file)
     print(f"Loaded {len(traces)} resources from input")
-    terminate_instances(ec2, traces, dry_run)
+
+    ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
+    nat_traces = [t for t in traces if t["resource_type"] == "nat-gateway"]
+    other = len(traces) - len(ec2_traces) - len(nat_traces)
+    if other:
+        print(f"Skipping {other} unsupported resource types")
+
+    if ec2_traces:
+        terminate_instances(ec2, ec2_traces, dry_run)
+    if nat_traces:
+        delete_nat_gateways(ec2, nat_traces, dry_run)
 
 
 if __name__ == "__main__":

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -25,7 +25,7 @@ EC2_BATCH_SIZE = 1000
 VPCE_BATCH_SIZE = 25
 
 
-def load_traces(input_file):
+def load_traces(input_file, include_questionable=False):
     if input_file == "-":
         data = sys.stdin.read()
     else:
@@ -37,7 +37,10 @@ def load_traces(input_file):
         print("Error: expected a JSON array")
         sys.exit(1)
 
-    allowed_prunability = {"prunable", "questionable"}
+    allowed_prunability = {"prunable"}
+    if include_questionable:
+        allowed_prunability.add("questionable")
+
     required_fields = {"resource_id", "resource_type", "state"}
     for t in traces:
         missing = required_fields - t.keys()
@@ -47,7 +50,8 @@ def load_traces(input_file):
 
     rejected = [t for t in traces if t.get("prunability") not in allowed_prunability]
     if rejected:
-        print(f"Refusing to delete {len(rejected)} resources not marked prunable or questionable:")
+        label = "prunable or questionable" if include_questionable else "prunable"
+        print(f"Refusing to delete {len(rejected)} resources not marked {label}:")
         for t in rejected:
             print(f"  {t['resource_id']} (prunability={t.get('prunability', '<missing>')})")
         sys.exit(1)
@@ -226,6 +230,10 @@ def main():
         default="us-west-2",
         help="AWS region (default: us-west-2)",
     )
+    parser.add_argument(
+        "--include-questionable", action="store_true",
+        help="Also accept resources marked 'questionable' (default: only 'prunable')",
+    )
 
     args = parser.parse_args()
     dry_run = args.dry_run == "true"
@@ -236,6 +244,8 @@ def main():
         print("Mode: DRY RUN")
     else:
         print("Mode: LIVE — resources will be deleted")
+    if args.include_questionable:
+        print("Accepting: prunable + questionable")
     print(f"Region: {args.region}\n")
 
     try:
@@ -244,7 +254,7 @@ def main():
         print("Error: AWS credentials not found.")
         sys.exit(1)
 
-    traces = load_traces(args.input_file)
+    traces = load_traces(args.input_file, args.include_questionable)
     print(f"Loaded {len(traces)} resources from input")
 
     ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -97,7 +97,7 @@ def terminate_instances(ec2, traces, dry_run):
         return
 
     print(f"\n=== TERMINATING {len(actionable)} instances ===\n")
-    instance_ids = [t["resource_id"] for t in actionable]
+    instance_ids = list(dict.fromkeys(t["resource_id"] for t in actionable))
     success = 0
     failed = []
 
@@ -184,7 +184,7 @@ def delete_vpc_endpoints(ec2, traces, dry_run):
         return
 
     print(f"\n=== DELETING {len(actionable)} VPC endpoints ===\n")
-    endpoint_ids = [t["resource_id"] for t in actionable]
+    endpoint_ids = list(dict.fromkeys(t["resource_id"] for t in actionable))
     success = 0
     failed = []
 

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -38,9 +38,11 @@ def load_traces(input_file):
         sys.exit(1)
 
     allowed_prunability = {"prunable", "questionable"}
+    required_fields = {"resource_id", "resource_type", "state"}
     for t in traces:
-        if "resource_id" not in t or "resource_type" not in t:
-            print(f"Error: entry missing resource_id or resource_type: {t}")
+        missing = required_fields - t.keys()
+        if missing:
+            print(f"Error: entry missing {', '.join(sorted(missing))}: {t.get('resource_id', '<unknown>')}")
             sys.exit(1)
 
     rejected = [t for t in traces if t.get("prunability") not in allowed_prunability]

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -2,7 +2,7 @@
 AWS Resource Pruner
 
 Reads JSON output from resource_tracer.py and deletes the listed resources.
-Supports EC2 instances, NAT gateways, and VPC endpoints.
+Supports EC2 instances, NAT gateways, VPC endpoints, and Elastic IPs.
 
 Usage:
     # Dry run (default) — shows what would be deleted
@@ -210,6 +210,47 @@ def delete_vpc_endpoints(ec2, traces, dry_run):
             print(f"  {eid}")
 
 
+def release_eips(ec2, traces, dry_run):
+    if not traces:
+        print("No Elastic IPs to release.")
+        return
+
+    if dry_run:
+        _print_dry_run(traces, "Elastic IPs")
+        return
+
+    print(f"\n=== RELEASING {len(traces)} Elastic IPs ===\n")
+    success = 0
+    failed = []
+
+    for t in traces:
+        alloc_id = t["resource_id"]
+        public_ip = t.get("instance_type", "")
+        label = f"{alloc_id} ({public_ip})" if public_ip else alloc_id
+        try:
+            if t.get("state") == "associated":
+                assoc_id = t.get("tags", {}).get("AssociationId", "")
+                if not assoc_id:
+                    resp = ec2.describe_addresses(AllocationIds=[alloc_id])
+                    addrs = resp.get("Addresses", [])
+                    assoc_id = addrs[0].get("AssociationId", "") if addrs else ""
+                if assoc_id:
+                    print(f"  Disassociating {label}...")
+                    ec2.disassociate_address(AssociationId=assoc_id)
+            print(f"  Releasing {label}...")
+            ec2.release_address(AllocationId=alloc_id)
+            success += 1
+        except ClientError as e:
+            print(f"    Error: {e}")
+            failed.append(alloc_id)
+
+    print(f"\nResult: {success} released, {len(failed)} failed")
+    if failed:
+        print("Failed Elastic IP IDs:")
+        for aid in failed:
+            print(f"  {aid}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AWS Resource Pruner — deletes resources from resource_tracer.py JSON output"
@@ -260,7 +301,8 @@ def main():
     ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
     nat_traces = [t for t in traces if t["resource_type"] == "nat-gateway"]
     vpce_traces = [t for t in traces if t["resource_type"] == "vpc-endpoint"]
-    other = len(traces) - len(ec2_traces) - len(nat_traces) - len(vpce_traces)
+    eip_traces = [t for t in traces if t["resource_type"] == "eip"]
+    other = len(traces) - len(ec2_traces) - len(nat_traces) - len(vpce_traces) - len(eip_traces)
     if other:
         print(f"Skipping {other} unsupported resource types")
 
@@ -270,6 +312,8 @@ def main():
         delete_nat_gateways(ec2, nat_traces, dry_run)
     if vpce_traces:
         delete_vpc_endpoints(ec2, vpce_traces, dry_run)
+    if eip_traces:
+        release_eips(ec2, eip_traces, dry_run)
 
 
 if __name__ == "__main__":

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -2,7 +2,7 @@
 AWS Resource Pruner
 
 Reads JSON output from resource_tracer.py and deletes the listed resources.
-Supports EC2 instances and NAT gateways.
+Supports EC2 instances, NAT gateways, and VPC endpoints.
 
 Usage:
     # Dry run (default) — shows what would be deleted
@@ -22,6 +22,7 @@ from botocore.exceptions import ClientError, NoCredentialsError
 
 
 EC2_BATCH_SIZE = 1000
+VPCE_BATCH_SIZE = 25
 
 
 def load_traces(input_file):
@@ -153,6 +154,48 @@ def delete_nat_gateways(ec2, traces, dry_run):
             print(f"  {nid}")
 
 
+def delete_vpc_endpoints(ec2, traces, dry_run):
+    skip_states = {"deleted", "deleting"}
+    actionable = [t for t in traces if t.get("state", "") not in skip_states]
+    skipped = len(traces) - len(actionable)
+    if skipped:
+        print(f"Skipping {skipped} already deleted/deleting VPC endpoints")
+
+    if not actionable:
+        print("No VPC endpoints to delete.")
+        return
+
+    if dry_run:
+        _print_dry_run(actionable, "VPC endpoints")
+        return
+
+    print(f"\n=== DELETING {len(actionable)} VPC endpoints ===\n")
+    endpoint_ids = [t["resource_id"] for t in actionable]
+    success = 0
+    failed = []
+
+    for i in range(0, len(endpoint_ids), VPCE_BATCH_SIZE):
+        batch = endpoint_ids[i : i + VPCE_BATCH_SIZE]
+        print(f"Deleting batch of {len(batch)} VPC endpoints...")
+        for eid in batch:
+            print(f"  {eid}")
+        try:
+            resp = ec2.delete_vpc_endpoints(VpcEndpointIds=batch)
+            unsuccessful = resp.get("Unsuccessful", [])
+            batch_failed = [item["ResourceId"] for item in unsuccessful]
+            failed.extend(batch_failed)
+            success += len(batch) - len(batch_failed)
+        except ClientError as e:
+            print(f"  Error deleting batch: {e}")
+            failed.extend(batch)
+
+    print(f"\nResult: {success} deleted, {len(failed)} failed")
+    if failed:
+        print("Failed VPC endpoint IDs:")
+        for eid in failed:
+            print(f"  {eid}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AWS Resource Pruner — deletes resources from resource_tracer.py JSON output"
@@ -196,7 +239,8 @@ def main():
 
     ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
     nat_traces = [t for t in traces if t["resource_type"] == "nat-gateway"]
-    other = len(traces) - len(ec2_traces) - len(nat_traces)
+    vpce_traces = [t for t in traces if t["resource_type"] == "vpc-endpoint"]
+    other = len(traces) - len(ec2_traces) - len(nat_traces) - len(vpce_traces)
     if other:
         print(f"Skipping {other} unsupported resource types")
 
@@ -204,6 +248,8 @@ def main():
         terminate_instances(ec2, ec2_traces, dry_run)
     if nat_traces:
         delete_nat_gateways(ec2, nat_traces, dry_run)
+    if vpce_traces:
+        delete_vpc_endpoints(ec2, vpce_traces, dry_run)
 
 
 if __name__ == "__main__":

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -41,7 +41,7 @@ def load_traces(input_file, include_questionable=False):
     if include_questionable:
         allowed_prunability.add("questionable")
 
-    required_fields = {"resource_id", "resource_type", "state"}
+    required_fields = {"resource_id", "resource_type", "state", "prunability"}
     for t in traces:
         missing = required_fields - t.keys()
         if missing:

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -37,10 +37,18 @@ def load_traces(input_file):
         print("Error: expected a JSON array")
         sys.exit(1)
 
+    allowed_prunability = {"prunable", "questionable"}
     for t in traces:
         if "resource_id" not in t or "resource_type" not in t:
             print(f"Error: entry missing resource_id or resource_type: {t}")
             sys.exit(1)
+
+    rejected = [t for t in traces if t.get("prunability") not in allowed_prunability]
+    if rejected:
+        print(f"Refusing to delete {len(rejected)} resources not marked prunable or questionable:")
+        for t in rejected:
+            print(f"  {t['resource_id']} (prunability={t.get('prunability', '<missing>')})")
+        sys.exit(1)
 
     return traces
 

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -1,0 +1,163 @@
+"""
+AWS Resource Pruner
+
+Reads JSON output from resource_tracer.py and terminates the listed EC2 instances.
+
+Usage:
+    # Dry run (default) — shows what would be terminated
+    python src/resource_tracer.py --scan --region us-east-1 --filter prunable --output json | \
+        python src/resource_pruner.py --region us-east-1 -
+
+    # Actual termination
+    python src/resource_pruner.py --region us-east-1 --dry-run false prunable.json
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+
+BATCH_SIZE = 1000
+
+
+def load_traces(input_file):
+    if input_file == "-":
+        data = sys.stdin.read()
+    else:
+        with open(input_file) as f:
+            data = f.read()
+
+    traces = json.loads(data)
+    if not isinstance(traces, list):
+        print("Error: expected a JSON array")
+        sys.exit(1)
+
+    for t in traces:
+        if "resource_id" not in t or "resource_type" not in t:
+            print(f"Error: entry missing resource_id or resource_type: {t}")
+            sys.exit(1)
+
+    return traces
+
+
+def terminate_instances(ec2, traces, dry_run):
+    ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
+    skipped_type = len(traces) - len(ec2_traces)
+    if skipped_type:
+        print(f"Skipping {skipped_type} non-EC2 resources")
+
+    skip_states = {"terminated", "terminating"}
+    actionable = [t for t in ec2_traces if t.get("state", "") not in skip_states]
+    skipped_state = len(ec2_traces) - len(actionable)
+    if skipped_state:
+        print(f"Skipping {skipped_state} already terminated/terminating instances")
+
+    if not actionable:
+        print("No instances to terminate.")
+        return
+
+    by_cluster = defaultdict(list)
+    for t in actionable:
+        key = t.get("cluster_name") or "Unassociated"
+        by_cluster[key].append(t)
+
+    if dry_run:
+        print(f"\n=== DRY RUN — {len(actionable)} instances would be terminated ===\n")
+        for cluster, instances in sorted(by_cluster.items()):
+            cluster_type = instances[0].get("cluster_type", "unknown")
+            prunability = instances[0].get("prunability", "")
+            label = f"{cluster} ({cluster_type})"
+            if prunability:
+                label += f" [{prunability.upper()}]"
+            print(f"  {label}")
+            for t in instances:
+                print(f"    {t['resource_id']}  {t.get('instance_type', '')}  {t.get('state', '')}")
+            print()
+        print(f"Total: {len(actionable)} instances across {len(by_cluster)} clusters")
+        print("Run with --dry-run false to terminate.")
+        return
+
+    print(f"\n=== TERMINATING {len(actionable)} instances ===\n")
+    instance_ids = [t["resource_id"] for t in actionable]
+    success = 0
+    failed = []
+
+    for i in range(0, len(instance_ids), BATCH_SIZE):
+        batch = instance_ids[i : i + BATCH_SIZE]
+        print(f"Terminating batch of {len(batch)} instances...")
+        for iid in batch:
+            print(f"  {iid}")
+        try:
+            ec2.terminate_instances(InstanceIds=batch)
+            success += len(batch)
+        except ClientError as e:
+            print(f"  Error terminating batch: {e}")
+            failed.extend(batch)
+
+    if success:
+        print(f"\nWaiting for {success} instances to reach terminated state...")
+        try:
+            waiter = ec2.get_waiter("instance_terminated")
+            waiter.wait(
+                InstanceIds=[iid for iid in instance_ids if iid not in failed],
+                WaiterConfig={"Delay": 15, "MaxAttempts": 40},
+            )
+            print("All instances terminated.")
+        except Exception as e:
+            print(f"Warning: waiter error (instances may still be terminating): {e}")
+
+    print(f"\nResult: {success} terminated, {len(failed)} failed")
+    if failed:
+        print("Failed instance IDs:")
+        for iid in failed:
+            print(f"  {iid}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AWS Resource Pruner — terminates EC2 instances from resource_tracer.py JSON output"
+    )
+    parser.add_argument(
+        "input_file",
+        help='Path to JSON file from resource_tracer.py, or "-" for stdin',
+    )
+    parser.add_argument(
+        "--dry-run",
+        type=str,
+        choices=["true", "false"],
+        default="true",
+        help="Dry-run mode: true or false (default: true)",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-west-2",
+        help="AWS region (default: us-west-2)",
+    )
+
+    args = parser.parse_args()
+    dry_run = args.dry_run == "true"
+
+    print("AWS Resource Pruner")
+    print("=" * 40)
+    if dry_run:
+        print("Mode: DRY RUN")
+    else:
+        print("Mode: LIVE — instances will be terminated")
+    print(f"Region: {args.region}\n")
+
+    try:
+        ec2 = boto3.Session(region_name=args.region).client("ec2")
+    except NoCredentialsError:
+        print("Error: AWS credentials not found.")
+        sys.exit(1)
+
+    traces = load_traces(args.input_file)
+    print(f"Loaded {len(traces)} resources from input")
+    terminate_instances(ec2, traces, dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/resource_pruner.py
+++ b/src/resource_pruner.py
@@ -279,6 +279,8 @@ def main():
     args = parser.parse_args()
     dry_run = args.dry_run == "true"
 
+    traces = load_traces(args.input_file, args.include_questionable)
+
     print("AWS Resource Pruner")
     print("=" * 40)
     if dry_run:
@@ -287,16 +289,14 @@ def main():
         print("Mode: LIVE — resources will be deleted")
     if args.include_questionable:
         print("Accepting: prunable + questionable")
-    print(f"Region: {args.region}\n")
+    print(f"Region: {args.region}")
+    print(f"Loaded {len(traces)} resources from input\n")
 
     try:
         ec2 = boto3.Session(region_name=args.region).client("ec2")
     except NoCredentialsError:
         print("Error: AWS credentials not found.")
         sys.exit(1)
-
-    traces = load_traces(args.input_file, args.include_questionable)
-    print(f"Loaded {len(traces)} resources from input")
 
     ec2_traces = [t for t in traces if t["resource_type"] == "ec2"]
     nat_traces = [t for t in traces if t["resource_type"] == "nat-gateway"]

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -458,6 +458,12 @@ def classify_prunability(traces, ocm_clusters, age_threshold=30):
             else:
                 trace.prunability = "not-prunable"
 
+        elif trace.cluster_type == "unknown":
+            if age >= age_threshold:
+                trace.prunability = "questionable"
+            else:
+                trace.prunability = "not-prunable"
+
         else:
             trace.prunability = "not-prunable"
 

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -440,7 +440,7 @@ def classify_prunability(traces, ocm_clusters, age_threshold=30):
         if trace.cluster_type == "prow-ci":
             if trace.is_expired:
                 trace.prunability = "prunable"
-            elif not trace.expiration_date:
+            elif not trace.expiration_date and age >= age_threshold:
                 trace.prunability = "questionable"
             else:
                 trace.prunability = "not-prunable"

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -2,12 +2,13 @@
 AWS Resource Tracer
 
 Read-only inspection tool that traces AWS resources back to their OpenShift
-clusters and identifies who provisioned them. Currently supports EC2 instances.
+clusters and identifies who provisioned them. Supports EC2 instances and
+NAT gateways.
 
 Usage:
   python src/resource_tracer.py i-01d154018d489351c --region us-east-1
   python src/resource_tracer.py --scan --region us-east-1
-  python src/resource_tracer.py --scan --region us-west-2 --skip-ocm
+  python src/resource_tracer.py --scan --region us-east-1 --resource-type nat-gateway
 """
 
 import argparse
@@ -21,6 +22,17 @@ from dataclasses import dataclass, field, asdict
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
+
+
+RESOURCE_TYPE_LABELS = {
+    "ec2": "EC2 Instances",
+    "nat-gateway": "NAT Gateways",
+}
+
+DEFAULT_STATES = {
+    "ec2": "running,stopped",
+    "nat-gateway": "available,failed",
+}
 
 
 @dataclass
@@ -47,7 +59,7 @@ class ResourceTrace:
     tags: dict = field(default_factory=dict)
 
 
-# ── EC2 fetching ──────────────────────────────────────────────
+# ── Fetching ─────────────────────────────────────────────────
 
 def fetch_ec2_instances(ec2_client, instance_ids=None, states=None):
     instances = []
@@ -77,10 +89,33 @@ def fetch_ec2_instances(ec2_client, instance_ids=None, states=None):
     return instances
 
 
+def fetch_nat_gateways(ec2_client, nat_gateway_ids=None, states=None):
+    gateways = []
+    paginator = ec2_client.get_paginator("describe_nat_gateways")
+
+    try:
+        if nat_gateway_ids:
+            pages = paginator.paginate(NatGatewayIds=nat_gateway_ids)
+        elif states:
+            pages = paginator.paginate(
+                Filters=[{"Name": "state", "Values": states}]
+            )
+        else:
+            pages = paginator.paginate()
+
+        for page in pages:
+            gateways.extend(page["NatGateways"])
+
+    except ClientError as e:
+        print(f"Error fetching NAT gateways: {e}")
+
+    return gateways
+
+
 # ── Tag helpers ───────────────────────────────────────────────
 
-def _tags_to_dict(instance):
-    return {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+def _tags_to_dict(resource):
+    return {t["Key"]: t["Value"] for t in resource.get("Tags", [])}
 
 
 def _get_kubernetes_cluster_name(tags):
@@ -135,22 +170,9 @@ def _age_days(launch_time_str, now):
 
 # ── Classification ────────────────────────────────────────────
 
-def classify_ec2_instance(instance):
-    tags = _tags_to_dict(instance)
+def _classify_by_tags(tags, trace):
     k8s_cluster = _get_kubernetes_cluster_name(tags)
     exp_dt, is_expired = _parse_expiration(tags)
-    launch_time = instance.get("LaunchTime")
-
-    trace = ResourceTrace(
-        resource_id=instance["InstanceId"],
-        resource_type="ec2",
-        instance_type=instance.get("InstanceType", ""),
-        state=instance.get("State", {}).get("Name", ""),
-        name=tags.get("Name", ""),
-        launch_time=launch_time.isoformat() if launch_time else "",
-        age_str=_format_age(launch_time),
-        tags=tags,
-    )
 
     if exp_dt:
         trace.expiration_date = exp_dt.isoformat()
@@ -194,6 +216,39 @@ def classify_ec2_instance(instance):
     # 5. Unknown
     trace.cluster_type = "unknown"
     return trace
+
+
+def classify_ec2_instance(instance):
+    tags = _tags_to_dict(instance)
+    launch_time = instance.get("LaunchTime")
+
+    trace = ResourceTrace(
+        resource_id=instance["InstanceId"],
+        resource_type="ec2",
+        instance_type=instance.get("InstanceType", ""),
+        state=instance.get("State", {}).get("Name", ""),
+        name=tags.get("Name", ""),
+        launch_time=launch_time.isoformat() if launch_time else "",
+        age_str=_format_age(launch_time),
+        tags=tags,
+    )
+    return _classify_by_tags(tags, trace)
+
+
+def classify_nat_gateway(nat_gw):
+    tags = _tags_to_dict(nat_gw)
+    create_time = nat_gw.get("CreateTime")
+
+    trace = ResourceTrace(
+        resource_id=nat_gw["NatGatewayId"],
+        resource_type="nat-gateway",
+        state=nat_gw.get("State", ""),
+        name=tags.get("Name", ""),
+        launch_time=create_time.isoformat() if create_time else "",
+        age_str=_format_age(create_time),
+        tags=tags,
+    )
+    return _classify_by_tags(tags, trace)
 
 
 # ── OCM integration ──────────────────────────────────────────
@@ -396,12 +451,13 @@ def group_by_cluster(traces):
 
 # ── Text report ───────────────────────────────────────────────
 
-def format_text_report(traces, region):
+def format_text_report(traces, region, resource_type="ec2"):
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    rt_label = RESOURCE_TYPE_LABELS.get(resource_type, resource_type)
     lines = []
-    lines.append(f"AWS Resource Tracer — {region} (EC2 Instances)")
+    lines.append(f"AWS Resource Tracer — {region} ({rt_label})")
     lines.append("=" * 60)
-    lines.append(f"Scanned: {len(traces)} instances | {now_str}")
+    lines.append(f"Scanned: {len(traces)} resources | {now_str}")
     lines.append("")
 
     grouped = group_by_cluster(traces)
@@ -440,13 +496,13 @@ def format_text_report(traces, region):
 
         lines.append("")
         lines.append(
-            f"   {'INSTANCE':<24} {'TYPE':<14} {'STATE':<10} {'LAUNCHED':<13} {'AGE':<8} {'NAME'}"
+            f"   {'RESOURCE':<24} {'TYPE':<14} {'STATE':<10} {'CREATED':<13} {'AGE':<8} {'NAME'}"
         )
         for t in sorted(group, key=lambda x: x.resource_id):
-            launched = t.launch_time[:10] if t.launch_time else ""
+            created = t.launch_time[:10] if t.launch_time else ""
             name_col = t.name if cluster_type == "unknown" else ""
             lines.append(
-                f"   {t.resource_id:<24} {t.instance_type:<14} {t.state:<10} {launched:<13} {t.age_str:<8} {name_col}"
+                f"   {t.resource_id:<24} {t.instance_type:<14} {t.state:<10} {created:<13} {t.age_str:<8} {name_col}"
             )
         lines.append("")
 
@@ -495,26 +551,26 @@ def _type_label(cluster_type):
 def _format_summary(traces, grouped):
     lines = ["=" * 60, "Summary", "=" * 60]
 
-    type_counts = defaultdict(lambda: {"instances": 0, "clusters": set(), "expired_clusters": set()})
+    type_counts = defaultdict(lambda: {"resources": 0, "clusters": set(), "expired_clusters": set()})
     for (cluster_name, cluster_type), group in grouped:
         tc = type_counts[cluster_type]
-        tc["instances"] += len(group)
+        tc["resources"] += len(group)
         tc["clusters"].add(cluster_name)
         if any(t.is_expired for t in group):
             tc["expired_clusters"].add(cluster_name)
 
-    lines.append(f"Total: {len(traces)} instances, {sum(len(tc['clusters']) for tc in type_counts.values())} clusters")
+    lines.append(f"Total: {len(traces)} resources, {sum(len(tc['clusters']) for tc in type_counts.values())} clusters")
     lines.append("")
 
     for ct in ["rosa-hcp", "rosa-classic", "osd", "osd-hcp", "ipi", "prow-ci", "unknown"]:
         tc = type_counts.get(ct)
-        if not tc or tc["instances"] == 0:
+        if not tc or tc["resources"] == 0:
             continue
         expired_note = ""
         if tc["expired_clusters"]:
             expired_note = f", {len(tc['expired_clusters'])} expired"
         lines.append(
-            f"  {_type_label(ct):<15} {tc['instances']:>4} instances  "
+            f"  {_type_label(ct):<15} {tc['resources']:>4} resources  "
             f"({len(tc['clusters'])} clusters{expired_note})"
         )
 
@@ -524,11 +580,11 @@ def _format_summary(traces, grouped):
         lines.append("")
         lines.append("Prunability:")
         if prunable_count:
-            lines.append(f"  Prunable:        {prunable_count:>4} instances")
+            lines.append(f"  Prunable:        {prunable_count:>4} resources")
         if questionable_count:
-            lines.append(f"  Questionable:    {questionable_count:>4} instances")
+            lines.append(f"  Questionable:    {questionable_count:>4} resources")
         not_prunable = len(traces) - prunable_count - questionable_count
-        lines.append(f"  Not prunable:    {not_prunable:>4} instances")
+        lines.append(f"  Not prunable:    {not_prunable:>4} resources")
 
     return "\n".join(lines)
 
@@ -541,14 +597,14 @@ def parse_args():
     )
     parser.add_argument(
         "resource_ids", nargs="*",
-        help="Resource IDs to trace (e.g., EC2 instance IDs)"
+        help="Resource IDs to trace (e.g., i-xxx for EC2, nat-xxx for NAT gateways)"
     )
     parser.add_argument(
         "--region", default="us-east-1",
         help="AWS region (default: us-east-1)"
     )
     parser.add_argument(
-        "--resource-type", default="ec2", choices=["ec2"],
+        "--resource-type", default="ec2", choices=["ec2", "nat-gateway"],
         help="Resource type to trace (default: ec2)"
     )
     parser.add_argument(
@@ -556,8 +612,8 @@ def parse_args():
         help="Scan all resources of the given type in the region"
     )
     parser.add_argument(
-        "--states", default="running,stopped",
-        help="Comma-separated instance states for --scan (default: running,stopped)"
+        "--states", default=None,
+        help="Comma-separated states for --scan (default: running,stopped for EC2; available,failed for NAT gateways)"
     )
     parser.add_argument(
         "--ocm-accounts", default="PROD,STAGE",
@@ -603,16 +659,26 @@ def main():
 
     skip_ocm = args.skip_ocm
     ocm_accounts = args.ocm_accounts.split(",")
+    resource_type = args.resource_type
+    state_list = (args.states or DEFAULT_STATES[resource_type]).split(",")
 
-    if args.scan:
-        state_list = args.states.split(",")
-        print(f"Scanning {args.region} for instances in states: {', '.join(state_list)}")
-        instances = fetch_ec2_instances(ec2_client, states=state_list)
-    else:
-        instances = fetch_ec2_instances(ec2_client, instance_ids=args.resource_ids)
+    if resource_type == "ec2":
+        if args.scan:
+            print(f"Scanning {args.region} for EC2 instances in states: {', '.join(state_list)}")
+            resources = fetch_ec2_instances(ec2_client, states=state_list)
+        else:
+            resources = fetch_ec2_instances(ec2_client, instance_ids=args.resource_ids)
+        print(f"Found {len(resources)} instances")
+        traces = [classify_ec2_instance(r) for r in resources]
 
-    print(f"Found {len(instances)} instances")
-    traces = [classify_ec2_instance(i) for i in instances]
+    elif resource_type == "nat-gateway":
+        if args.scan:
+            print(f"Scanning {args.region} for NAT gateways in states: {', '.join(state_list)}")
+            resources = fetch_nat_gateways(ec2_client, states=state_list)
+        else:
+            resources = fetch_nat_gateways(ec2_client, nat_gateway_ids=args.resource_ids)
+        print(f"Found {len(resources)} NAT gateways")
+        traces = [classify_nat_gateway(r) for r in resources]
 
     ocm_clusters = {}
     owner_cache = {}
@@ -629,7 +695,7 @@ def main():
         sys.stdout = real_stdout
         print(format_json_report(traces))
     else:
-        print(format_text_report(traces, args.region))
+        print(format_text_report(traces, args.region, resource_type))
 
 
 if __name__ == "__main__":

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -458,12 +458,6 @@ def classify_prunability(traces, ocm_clusters, age_threshold=30):
             else:
                 trace.prunability = "not-prunable"
 
-        elif trace.cluster_type == "unknown":
-            if age >= age_threshold:
-                trace.prunability = "questionable"
-            else:
-                trace.prunability = "not-prunable"
-
         else:
             trace.prunability = "not-prunable"
 

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -3,7 +3,7 @@ AWS Resource Tracer
 
 Read-only inspection tool that traces AWS resources back to their OpenShift
 clusters and identifies who provisioned them. Supports EC2 instances,
-NAT gateways, and VPC endpoints.
+NAT gateways, VPC endpoints, and Elastic IPs.
 
 Usage:
   python src/resource_tracer.py i-01d154018d489351c --region us-east-1
@@ -28,12 +28,14 @@ RESOURCE_TYPE_LABELS = {
     "ec2": "EC2 Instances",
     "nat-gateway": "NAT Gateways",
     "vpc-endpoint": "VPC Endpoints",
+    "eip": "Elastic IPs",
 }
 
 DEFAULT_STATES = {
     "ec2": "running,stopped",
     "nat-gateway": "available,failed",
     "vpc-endpoint": "available,pending",
+    "eip": "all",
 }
 
 
@@ -135,6 +137,20 @@ def fetch_vpc_endpoints(ec2_client, endpoint_ids=None, states=None):
         print(f"Error fetching VPC endpoints: {e}")
 
     return endpoints
+
+
+def fetch_eips(ec2_client, allocation_ids=None, states=None):
+    try:
+        if allocation_ids:
+            response = ec2_client.describe_addresses(AllocationIds=allocation_ids)
+        else:
+            response = ec2_client.describe_addresses(
+                Filters=[{"Name": "domain", "Values": ["vpc"]}]
+            )
+        return response.get("Addresses", [])
+    except ClientError as e:
+        print(f"Error fetching Elastic IPs: {e}")
+        return []
 
 
 # ── Tag helpers ───────────────────────────────────────────────
@@ -287,6 +303,21 @@ def classify_vpc_endpoint(endpoint):
         name=tags.get("Name", ""),
         launch_time=create_time.isoformat() if create_time else "",
         age_str=_format_age(create_time),
+        tags=tags,
+    )
+    return _classify_by_tags(tags, trace)
+
+
+def classify_eip(address):
+    tags = _tags_to_dict(address)
+    state = "associated" if address.get("AssociationId") else "unassociated"
+
+    trace = ResourceTrace(
+        resource_id=address["AllocationId"],
+        resource_type="eip",
+        instance_type=address.get("PublicIp", ""),
+        state=state,
+        name=tags.get("Name", ""),
         tags=tags,
     )
     return _classify_by_tags(tags, trace)
@@ -727,6 +758,7 @@ def main():
         "ec2": (fetch_ec2_instances, classify_ec2_instance, "instances"),
         "nat-gateway": (fetch_nat_gateways, classify_nat_gateway, "NAT gateways"),
         "vpc-endpoint": (fetch_vpc_endpoints, classify_vpc_endpoint, "VPC endpoints"),
+        "eip": (fetch_eips, classify_eip, "Elastic IPs"),
     }
 
     for rt in resource_types:
@@ -734,7 +766,10 @@ def main():
         state_list = (args.states or DEFAULT_STATES[rt]).split(",")
 
         if args.scan:
-            print(f"Scanning {args.region} for {label} in states: {', '.join(state_list)}")
+            if state_list == ["all"]:
+                print(f"Scanning {args.region} for {label}")
+            else:
+                print(f"Scanning {args.region} for {label} in states: {', '.join(state_list)}")
             resources = fetch_fn(ec2_client, states=state_list)
         else:
             resources = fetch_fn(ec2_client, args.resource_ids)

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -450,7 +450,7 @@ def classify_prunability(traces, ocm_clusters, age_threshold=30):
                 ocm_clusters.get(trace.cluster_name)
                 or ocm_clusters.get(trace.cluster_id)
             )
-            ocm_status = ocm_entry["status"] if ocm_entry else ""
+            ocm_status = ocm_entry.get("status", "") if ocm_entry else ""
             if ocm_status == "error":
                 trace.prunability = "questionable"
             elif age >= age_threshold:

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from collections import defaultdict
@@ -46,461 +47,425 @@ class ResourceTrace:
     tags: dict = field(default_factory=dict)
 
 
-class ResourceTracer:
-    def __init__(self, region="us-east-1", ocm_accounts=None, skip_ocm=False):
-        self.region = region
-        self.ocm_accounts = ocm_accounts or ["PROD", "STAGE"]
-        self.skip_ocm = skip_ocm
-        self.ocm_clusters = {}
-        self.owner_cache = {}
+# ── EC2 fetching ──────────────────────────────────────────────
 
-        try:
-            self.session = boto3.Session(region_name=region)
-            self.ec2_client = self.session.client("ec2")
-        except NoCredentialsError:
-            print("Error: AWS credentials not found.")
-            sys.exit(1)
+def fetch_ec2_instances(ec2_client, instance_ids=None, states=None):
+    instances = []
+    paginator = ec2_client.get_paginator("describe_instances")
 
-    # ── EC2 fetching ──────────────────────────────────────────────
+    try:
+        if instance_ids:
+            pages = paginator.paginate(InstanceIds=instance_ids)
+        elif states:
+            pages = paginator.paginate(
+                Filters=[{"Name": "instance-state-name", "Values": states}]
+            )
+        else:
+            pages = paginator.paginate()
 
-    def fetch_ec2_instances(self, instance_ids=None, states=None):
-        instances = []
-        paginator = self.ec2_client.get_paginator("describe_instances")
+        for page in pages:
+            for reservation in page["Reservations"]:
+                instances.extend(reservation["Instances"])
 
-        try:
-            if instance_ids:
-                pages = paginator.paginate(InstanceIds=instance_ids)
-            elif states:
-                pages = paginator.paginate(
-                    Filters=[{"Name": "instance-state-name", "Values": states}]
-                )
-            else:
-                pages = paginator.paginate()
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "InvalidInstanceID.NotFound":
+            print(f"Warning: {e.response['Error']['Message']}")
+        else:
+            print(f"Error fetching instances: {e}")
 
-            for page in pages:
-                for reservation in page["Reservations"]:
-                    instances.extend(reservation["Instances"])
+    return instances
 
-        except ClientError as e:
-            code = e.response["Error"]["Code"]
-            if code == "InvalidInstanceID.NotFound":
-                print(f"Warning: {e.response['Error']['Message']}")
-            else:
-                print(f"Error fetching instances: {e}")
 
-        return instances
+# ── Tag helpers ───────────────────────────────────────────────
 
-    # ── Tag helpers ───────────────────────────────────────────────
+def _tags_to_dict(instance):
+    return {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
 
-    def _tags_to_dict(self, instance):
-        return {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
 
-    def _get_kubernetes_cluster_name(self, tags):
-        for key, value in tags.items():
-            if key.startswith("kubernetes.io/cluster/") and value == "owned":
-                return key.split("kubernetes.io/cluster/")[1]
-        return None
+def _get_kubernetes_cluster_name(tags):
+    for key, value in tags.items():
+        if key.startswith("kubernetes.io/cluster/") and value == "owned":
+            return key.split("kubernetes.io/cluster/")[1]
+    return None
 
-    def _parse_expiration(self, tags):
-        raw = tags.get("expirationDate")
-        if not raw:
-            return None, False
-        try:
-            dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-            now = datetime.now(timezone.utc)
-            return dt, now > dt
-        except (ValueError, TypeError):
-            return None, False
 
-    def _format_age(self, dt):
-        if not dt:
-            return ""
-        if isinstance(dt, str):
-            try:
-                dt = datetime.fromisoformat(dt.replace("Z", "+00:00"))
-            except (ValueError, TypeError):
-                return ""
+def _parse_expiration(tags):
+    raw = tags.get("expirationDate")
+    if not raw:
+        return None, False
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
         now = datetime.now(timezone.utc)
+        return dt, now > dt
+    except (ValueError, TypeError):
+        return None, False
+
+
+def _format_age(dt):
+    if not dt:
+        return ""
+    if isinstance(dt, str):
+        try:
+            dt = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return ""
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = now - dt
+    days = delta.days
+    hours = delta.seconds // 3600
+    if days > 0:
+        return f"{days}d {hours}h"
+    return f"{hours}h"
+
+
+def _age_days(launch_time_str, now):
+    if not launch_time_str:
+        return 0
+    try:
+        dt = datetime.fromisoformat(launch_time_str.replace("Z", "+00:00"))
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        delta = now - dt
-        days = delta.days
-        hours = delta.seconds // 3600
-        if days > 0:
-            return f"{days}d {hours}h"
-        return f"{hours}h"
+        return (now - dt).days
+    except (ValueError, TypeError):
+        return 0
 
-    # ── Classification ────────────────────────────────────────────
 
-    def classify_ec2_instance(self, instance):
-        tags = self._tags_to_dict(instance)
-        k8s_cluster = self._get_kubernetes_cluster_name(tags)
-        exp_dt, is_expired = self._parse_expiration(tags)
-        launch_time = instance.get("LaunchTime")
+# ── Classification ────────────────────────────────────────────
 
-        trace = ResourceTrace(
-            resource_id=instance["InstanceId"],
-            resource_type="ec2",
-            instance_type=instance.get("InstanceType", ""),
-            state=instance.get("State", {}).get("Name", ""),
-            name=tags.get("Name", ""),
-            launch_time=launch_time.isoformat() if launch_time else "",
-            age_str=self._format_age(launch_time),
-            tags=tags,
-        )
+def classify_ec2_instance(instance):
+    tags = _tags_to_dict(instance)
+    k8s_cluster = _get_kubernetes_cluster_name(tags)
+    exp_dt, is_expired = _parse_expiration(tags)
+    launch_time = instance.get("LaunchTime")
 
-        if exp_dt:
-            trace.expiration_date = exp_dt.isoformat()
-            trace.is_expired = is_expired
-            if is_expired:
-                trace.expired_ago = self._format_age(exp_dt)
+    trace = ResourceTrace(
+        resource_id=instance["InstanceId"],
+        resource_type="ec2",
+        instance_type=instance.get("InstanceType", ""),
+        state=instance.get("State", {}).get("Name", ""),
+        name=tags.get("Name", ""),
+        launch_time=launch_time.isoformat() if launch_time else "",
+        age_str=_format_age(launch_time),
+        tags=tags,
+    )
 
-        # 1. Prow CI
-        if "prow.k8s.io/build-id" in tags and "prow.k8s.io/job" in tags:
-            trace.cluster_type = "prow-ci"
-            trace.prow_job = tags["prow.k8s.io/job"]
-            trace.prow_build_id = tags["prow.k8s.io/build-id"]
-            trace.cluster_name = k8s_cluster or ""
-            return trace
+    if exp_dt:
+        trace.expiration_date = exp_dt.isoformat()
+        trace.is_expired = is_expired
+        if is_expired:
+            trace.expired_ago = _format_age(exp_dt)
 
-        # 2. ROSA HCP — has api.openshift.com/name
-        if "api.openshift.com/name" in tags:
-            trace.cluster_name = tags["api.openshift.com/name"]
-            trace.cluster_id = tags.get("api.openshift.com/id", "")
-            clustertype = tags.get("red-hat-clustertype", "")
-            if clustertype == "osd":
-                trace.cluster_type = "osd-hcp"
-            else:
-                trace.cluster_type = "rosa-hcp"
-            return trace
-
-        # 3. ROSA Classic / OSD — has red-hat-clustertype but no api.openshift.com/name
-        if "red-hat-clustertype" in tags:
-            clustertype = tags["red-hat-clustertype"]
-            trace.cluster_type = "rosa-classic" if clustertype == "rosa" else "osd"
-            trace.cluster_id = tags.get("api.openshift.com/id", "")
-            trace.cluster_name = k8s_cluster or ""
-            return trace
-
-        # 4. IPI — has kubernetes.io/cluster/* with owned
-        if k8s_cluster:
-            trace.cluster_type = "ipi"
-            trace.cluster_name = k8s_cluster
-            return trace
-
-        # 5. Unknown
-        trace.cluster_type = "unknown"
+    # 1. Prow CI
+    if "prow.k8s.io/build-id" in tags and "prow.k8s.io/job" in tags:
+        trace.cluster_type = "prow-ci"
+        trace.prow_job = tags["prow.k8s.io/job"]
+        trace.prow_build_id = tags["prow.k8s.io/build-id"]
+        trace.cluster_name = k8s_cluster or ""
         return trace
 
-    # ── OCM integration ──────────────────────────────────────────
+    # 2. ROSA HCP — has api.openshift.com/name
+    if "api.openshift.com/name" in tags:
+        trace.cluster_name = tags["api.openshift.com/name"]
+        trace.cluster_id = tags.get("api.openshift.com/id", "")
+        clustertype = tags.get("red-hat-clustertype", "")
+        if clustertype == "osd":
+            trace.cluster_type = "osd-hcp"
+        else:
+            trace.cluster_type = "rosa-hcp"
+        return trace
 
-    def load_ocm_clusters(self):
-        if self.skip_ocm:
-            return
+    # 3. ROSA Classic / OSD — has red-hat-clustertype but no api.openshift.com/name
+    if "red-hat-clustertype" in tags:
+        clustertype = tags["red-hat-clustertype"]
+        trace.cluster_type = "rosa-classic" if clustertype == "rosa" else "osd"
+        trace.cluster_id = tags.get("api.openshift.com/id", "")
+        trace.cluster_name = k8s_cluster or ""
+        return trace
 
-        for account in self.ocm_accounts:
-            if self._ocm_login(account):
-                clusters = self._ocm_list_clusters(account)
-                self.ocm_clusters.update(clusters)
+    # 4. IPI — has kubernetes.io/cluster/* with owned
+    if k8s_cluster:
+        trace.cluster_type = "ipi"
+        trace.cluster_name = k8s_cluster
+        return trace
 
-    def _ocm_login(self, account):
-        token = _get_ocm_token()
-        if not token:
-            # No token set — try using whatever session is already active
-            result = subprocess.run(
-                ["ocm", "whoami"], capture_output=True, text=True,
-            )
-            if result.returncode == 0:
-                return True
-            print(f"Warning: OCM_TOKEN not set and no active session for {account}")
-            return False
+    # 5. Unknown
+    trace.cluster_type = "unknown"
+    return trace
 
-        cmd = ["ocm", "login", "--token", token]
-        if account == "STAGE":
-            cmd.extend(["--url", "stage"])
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            print(f"Warning: OCM login failed for {account}: {result.stderr.strip()}")
-            return False
-        return True
 
-    def _ocm_list_clusters(self, account):
-        clusters = {}
-        page = 1
-        page_size = 100
+# ── OCM integration ──────────────────────────────────────────
 
-        while True:
-            result = subprocess.run(
-                ["ocm", "get", "/api/clusters_mgmt/v1/clusters",
-                 "--parameter", f"page={page}",
-                 "--parameter", f"size={page_size}"],
-                capture_output=True, text=True,
-            )
-            if result.returncode != 0:
-                print(f"Warning: Could not list OCM clusters ({account}): {result.stderr.strip()}")
-                return clusters
-
-            try:
-                data = json.loads(result.stdout)
-            except json.JSONDecodeError:
-                print(f"Warning: Invalid JSON from OCM cluster list ({account})")
-                return clusters
-
-            for item in data.get("items", []):
-                cluster_id = item.get("id", "")
-                name = item.get("name", "")
-                entry = {
-                    "id": cluster_id,
-                    "name": name,
-                    "type": item.get("product", {}).get("id", ""),
-                    "hcp": str(item.get("hypershift", {}).get("enabled", False)).lower(),
-                    "region": item.get("region", {}).get("id", ""),
-                    "status": item.get("state", ""),
-                    "ocm_account": account,
-                }
-                clusters[name] = entry
-                clusters[cluster_id] = entry
-
-            total = data.get("total", 0)
-            if page * page_size >= total:
-                break
-            page += 1
-
-        return clusters
-
-    def lookup_cluster_owner(self, cluster_id, ocm_account):
-        if cluster_id in self.owner_cache:
-            return self.owner_cache[cluster_id]
-
+def _ocm_login(account):
+    token = os.environ.get("OCM_TOKEN", "")
+    if not token:
         result = subprocess.run(
-            ["ocm", "get", "/api/accounts_mgmt/v1/subscriptions",
-             "-p", f"search=cluster_id='{cluster_id}'",
-             "--parameter", "fetchAccounts=true"],
+            ["ocm", "whoami"], capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            return True
+        print(f"Warning: OCM_TOKEN not set and no active session for {account}")
+        return False
+
+    cmd = ["ocm", "login", "--token", token]
+    if account == "STAGE":
+        cmd.extend(["--url", "stage"])
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Warning: OCM login failed for {account}: {result.stderr.strip()}")
+        return False
+    return True
+
+
+def _ocm_list_clusters(account):
+    clusters = {}
+    page = 1
+    page_size = 100
+
+    while True:
+        result = subprocess.run(
+            ["ocm", "get", "/api/clusters_mgmt/v1/clusters",
+             "--parameter", f"page={page}",
+             "--parameter", f"size={page_size}"],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
-            self.owner_cache[cluster_id] = ("", "")
-            return ("", "")
+            print(f"Warning: Could not list OCM clusters ({account}): {result.stderr.strip()}")
+            return clusters
 
         try:
             data = json.loads(result.stdout)
-            items = data.get("items", [])
-            if not items:
-                self.owner_cache[cluster_id] = ("", "")
-                return ("", "")
-            creator = items[0].get("creator", {})
-            name = creator.get("name", "") or \
-                f"{creator.get('first_name', '')} {creator.get('last_name', '')}".strip()
-            email = get_original_email_address(creator.get("email", ""))
-            self.owner_cache[cluster_id] = (name, email)
-            return (name, email)
-        except (json.JSONDecodeError, KeyError, IndexError):
-            self.owner_cache[cluster_id] = ("", "")
+        except json.JSONDecodeError:
+            print(f"Warning: Invalid JSON from OCM cluster list ({account})")
+            return clusters
+
+        for item in data.get("items", []):
+            cluster_id = item.get("id", "")
+            name = item.get("name", "")
+            entry = {
+                "id": cluster_id,
+                "name": name,
+                "type": item.get("product", {}).get("id", ""),
+                "hcp": str(item.get("hypershift", {}).get("enabled", False)).lower(),
+                "region": item.get("region", {}).get("id", ""),
+                "status": item.get("state", ""),
+                "ocm_account": account,
+            }
+            clusters[name] = entry
+            clusters[cluster_id] = entry
+
+        total = data.get("total", 0)
+        if page * page_size >= total:
+            break
+        page += 1
+
+    return clusters
+
+
+def load_ocm_clusters(ocm_accounts):
+    ocm_clusters = {}
+    for account in ocm_accounts:
+        if _ocm_login(account):
+            clusters = _ocm_list_clusters(account)
+            ocm_clusters.update(clusters)
+    return ocm_clusters
+
+
+def lookup_cluster_owner(cluster_id, owner_cache):
+    if cluster_id in owner_cache:
+        return owner_cache[cluster_id]
+
+    result = subprocess.run(
+        ["ocm", "get", "/api/accounts_mgmt/v1/subscriptions",
+         "-p", f"search=cluster_id='{cluster_id}'",
+         "--parameter", "fetchAccounts=true"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        owner_cache[cluster_id] = ("", "")
+        return ("", "")
+
+    try:
+        data = json.loads(result.stdout)
+        items = data.get("items", [])
+        if not items:
+            owner_cache[cluster_id] = ("", "")
             return ("", "")
+        creator = items[0].get("creator", {})
+        name = creator.get("name", "") or \
+            f"{creator.get('first_name', '')} {creator.get('last_name', '')}".strip()
+        email = _get_original_email_address(creator.get("email", ""))
+        owner_cache[cluster_id] = (name, email)
+        return (name, email)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        owner_cache[cluster_id] = ("", "")
+        return ("", "")
 
-    def enrich_with_ocm(self, traces):
-        if self.skip_ocm:
-            return
 
-        # Group clusters by OCM account so we login once per account
-        by_account = defaultdict(dict)
-        for trace in traces:
-            if trace.cluster_type in ("unknown", "prow-ci"):
-                continue
-            ocm_entry = (
-                self.ocm_clusters.get(trace.cluster_name)
-                or self.ocm_clusters.get(trace.cluster_id)
-            )
-            if ocm_entry:
-                trace.ocm_account = ocm_entry["ocm_account"]
-                cid = ocm_entry["id"]
-                trace.cluster_id = cid
-                account = ocm_entry["ocm_account"]
-                if cid not in by_account[account]:
-                    by_account[account][cid] = []
-                by_account[account][cid].append(trace)
+def enrich_with_ocm(traces, ocm_clusters, owner_cache):
+    by_account = defaultdict(dict)
+    for trace in traces:
+        if trace.cluster_type in ("unknown", "prow-ci"):
+            continue
+        ocm_entry = (
+            ocm_clusters.get(trace.cluster_name)
+            or ocm_clusters.get(trace.cluster_id)
+        )
+        if ocm_entry:
+            trace.ocm_account = ocm_entry["ocm_account"]
+            cid = ocm_entry["id"]
+            trace.cluster_id = cid
+            account = ocm_entry["ocm_account"]
+            if cid not in by_account[account]:
+                by_account[account][cid] = []
+            by_account[account][cid].append(trace)
 
-        for account, cluster_map in by_account.items():
-            if not self._ocm_login(account):
-                continue
-            for cluster_id, group_traces in cluster_map.items():
-                owner_name, owner_email = self.lookup_cluster_owner(cluster_id, account)
-                for t in group_traces:
-                    t.owner_name = owner_name
-                    t.owner_email = owner_email
+    for account, cluster_map in by_account.items():
+        if not _ocm_login(account):
+            continue
+        for cluster_id, group_traces in cluster_map.items():
+            owner_name, owner_email = lookup_cluster_owner(cluster_id, owner_cache)
+            for t in group_traces:
+                t.owner_name = owner_name
+                t.owner_email = owner_email
 
-    # ── Prunability ────────────────────────────────────────────────
 
-    def classify_prunability(self, traces, age_threshold=30):
-        now = datetime.now(timezone.utc)
-        managed_types = {"rosa-hcp", "rosa-classic", "osd", "osd-hcp", "ipi"}
+# ── Prunability ────────────────────────────────────────────────
 
-        for trace in traces:
-            age_days = self._age_days(trace.launch_time, now)
+def classify_prunability(traces, ocm_clusters, age_threshold=30):
+    now = datetime.now(timezone.utc)
+    managed_types = {"rosa-hcp", "rosa-classic", "osd", "osd-hcp", "ipi"}
 
-            if trace.cluster_type == "prow-ci":
-                if trace.is_expired:
-                    trace.prunability = "prunable"
-                elif not trace.expiration_date:
-                    trace.prunability = "questionable"
-                else:
-                    trace.prunability = "not-prunable"
+    for trace in traces:
+        age = _age_days(trace.launch_time, now)
 
-            elif trace.cluster_type in managed_types:
-                ocm_entry = (
-                    self.ocm_clusters.get(trace.cluster_name)
-                    or self.ocm_clusters.get(trace.cluster_id)
-                )
-                ocm_status = ocm_entry["status"] if ocm_entry else ""
-                if ocm_status == "error":
-                    trace.prunability = "questionable"
-                elif age_days >= age_threshold:
-                    trace.prunability = "questionable"
-                else:
-                    trace.prunability = "not-prunable"
-
-            elif trace.cluster_type == "unknown":
-                if age_days >= age_threshold:
-                    trace.prunability = "questionable"
-                else:
-                    trace.prunability = "not-prunable"
-
+        if trace.cluster_type == "prow-ci":
+            if trace.is_expired:
+                trace.prunability = "prunable"
+            elif not trace.expiration_date:
+                trace.prunability = "questionable"
             else:
                 trace.prunability = "not-prunable"
 
-    def _age_days(self, launch_time_str, now):
-        if not launch_time_str:
-            return 0
-        try:
-            dt = datetime.fromisoformat(launch_time_str.replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return (now - dt).days
-        except (ValueError, TypeError):
-            return 0
+        elif trace.cluster_type in managed_types:
+            ocm_entry = (
+                ocm_clusters.get(trace.cluster_name)
+                or ocm_clusters.get(trace.cluster_id)
+            )
+            ocm_status = ocm_entry["status"] if ocm_entry else ""
+            if ocm_status == "error":
+                trace.prunability = "questionable"
+            elif age >= age_threshold:
+                trace.prunability = "questionable"
+            else:
+                trace.prunability = "not-prunable"
 
-    @staticmethod
-    def filter_traces(traces, filter_value):
-        if not filter_value:
-            return traces
-        allowed = set(filter_value.split("+"))
-        return [t for t in traces if t.prunability in allowed]
+        elif trace.cluster_type == "unknown":
+            if age >= age_threshold:
+                trace.prunability = "questionable"
+            else:
+                trace.prunability = "not-prunable"
 
-    # ── Orchestration ─────────────────────────────────────────────
-
-    def trace(self, resource_ids=None, states=None, scan=False):
-        if scan:
-            state_list = states or ["running", "stopped"]
-            print(f"Scanning {self.region} for instances in states: {', '.join(state_list)}")
-            instances = self.fetch_ec2_instances(states=state_list)
-        elif resource_ids:
-            instances = self.fetch_ec2_instances(instance_ids=resource_ids)
         else:
-            print("Error: provide instance IDs or use --scan")
-            sys.exit(1)
+            trace.prunability = "not-prunable"
 
-        print(f"Found {len(instances)} instances")
 
-        traces = [self.classify_ec2_instance(i) for i in instances]
-
-        if not self.skip_ocm:
-            print("Loading OCM cluster data...")
-            self.load_ocm_clusters()
-            print(f"Loaded {len(self.ocm_clusters) // 2} clusters from OCM")
-            self.enrich_with_ocm(traces)
-
+def filter_traces(traces, filter_value):
+    if not filter_value:
         return traces
+    allowed = set(filter_value.split("+"))
+    return [t for t in traces if t.prunability in allowed]
 
-    # ── Grouping ──────────────────────────────────────────────────
 
-    def group_by_cluster(self, traces):
-        groups = defaultdict(list)
-        for t in traces:
-            key = (t.cluster_name or t.resource_id, t.cluster_type)
-            groups[key].append(t)
+# ── Grouping ──────────────────────────────────────────────────
 
-        type_order = {
-            "rosa-hcp": 0, "rosa-classic": 1, "osd": 2, "osd-hcp": 3,
-            "ipi": 4, "prow-ci": 5, "unknown": 6,
-        }
-        return sorted(groups.items(), key=lambda x: (type_order.get(x[0][1], 99), x[0][0]))
+def group_by_cluster(traces):
+    groups = defaultdict(list)
+    for t in traces:
+        key = (t.cluster_name or t.resource_id, t.cluster_type)
+        groups[key].append(t)
 
-    # ── Text report ───────────────────────────────────────────────
+    type_order = {
+        "rosa-hcp": 0, "rosa-classic": 1, "osd": 2, "osd-hcp": 3,
+        "ipi": 4, "prow-ci": 5, "unknown": 6,
+    }
+    return sorted(groups.items(), key=lambda x: (type_order.get(x[0][1], 99), x[0][0]))
 
-    def format_text_report(self, traces):
-        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-        lines = []
-        lines.append(f"AWS Resource Tracer — {self.region} (EC2 Instances)")
-        lines.append("=" * 60)
-        lines.append(f"Scanned: {len(traces)} instances | {now_str}")
+
+# ── Text report ───────────────────────────────────────────────
+
+def format_text_report(traces, region):
+    now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = []
+    lines.append(f"AWS Resource Tracer — {region} (EC2 Instances)")
+    lines.append("=" * 60)
+    lines.append(f"Scanned: {len(traces)} instances | {now_str}")
+    lines.append("")
+
+    grouped = group_by_cluster(traces)
+
+    for (cluster_name, cluster_type), group in grouped:
+        sample = group[0]
+
+        if cluster_type == "unknown":
+            label = "Unassociated"
+        else:
+            label = f"{cluster_name} ({_type_label(cluster_type)})"
+
+        prunability_tag = _prunability_tag(group)
+        if prunability_tag:
+            label += f" {prunability_tag}"
+
+        lines.append(f"── {label} " + "─" * max(1, 58 - len(label)))
+
+        if sample.owner_name or sample.owner_email:
+            owner = sample.owner_name
+            if sample.owner_email:
+                owner += f" <{sample.owner_email}>"
+            ocm = f" | OCM: {sample.ocm_account}" if sample.ocm_account else ""
+            lines.append(f"   Owner: {owner}{ocm}")
+
+        if cluster_type == "prow-ci" and sample.prow_job:
+            lines.append(f"   Job: {sample.prow_job}")
+            lines.append(f"   Build: {sample.prow_build_id}")
+
+        if sample.expiration_date:
+            exp_status = f"expired {sample.expired_ago} ago" if sample.is_expired else "active"
+            lines.append(f"   Expiration: {sample.expiration_date} ({exp_status})")
+
+        if sample.cluster_id:
+            lines.append(f"   Cluster ID: {sample.cluster_id}")
+
+        lines.append("")
+        lines.append(
+            f"   {'INSTANCE':<24} {'TYPE':<14} {'STATE':<10} {'LAUNCHED':<13} {'AGE':<8} {'NAME'}"
+        )
+        for t in sorted(group, key=lambda x: x.resource_id):
+            launched = t.launch_time[:10] if t.launch_time else ""
+            name_col = t.name if cluster_type == "unknown" else ""
+            lines.append(
+                f"   {t.resource_id:<24} {t.instance_type:<14} {t.state:<10} {launched:<13} {t.age_str:<8} {name_col}"
+            )
         lines.append("")
 
-        grouped = self.group_by_cluster(traces)
+    lines.append(_format_summary(traces, grouped))
+    return "\n".join(lines)
 
-        for (cluster_name, cluster_type), group in grouped:
-            sample = group[0]
 
-            if cluster_type == "unknown":
-                label = "Unassociated"
-            else:
-                label = f"{cluster_name} ({_type_label(cluster_type)})"
-
-            prunability_tag = _prunability_tag(group)
-            if prunability_tag:
-                label += f" {prunability_tag}"
-
-            lines.append(f"── {label} " + "─" * max(1, 58 - len(label)))
-
-            if sample.owner_name or sample.owner_email:
-                owner = sample.owner_name
-                if sample.owner_email:
-                    owner += f" <{sample.owner_email}>"
-                ocm = f" | OCM: {sample.ocm_account}" if sample.ocm_account else ""
-                lines.append(f"   Owner: {owner}{ocm}")
-
-            if cluster_type == "prow-ci" and sample.prow_job:
-                lines.append(f"   Job: {sample.prow_job}")
-                lines.append(f"   Build: {sample.prow_build_id}")
-
-            if sample.expiration_date:
-                exp_status = f"expired {sample.expired_ago} ago" if sample.is_expired else "active"
-                lines.append(f"   Expiration: {sample.expiration_date} ({exp_status})")
-
-            if sample.cluster_id:
-                lines.append(f"   Cluster ID: {sample.cluster_id}")
-
-            lines.append("")
-            lines.append(
-                f"   {'INSTANCE':<24} {'TYPE':<14} {'STATE':<10} {'LAUNCHED':<13} {'AGE':<8} {'NAME'}"
-            )
-            for t in sorted(group, key=lambda x: x.resource_id):
-                launched = t.launch_time[:10] if t.launch_time else ""
-                name_col = t.name if cluster_type == "unknown" else ""
-                lines.append(
-                    f"   {t.resource_id:<24} {t.instance_type:<14} {t.state:<10} {launched:<13} {t.age_str:<8} {name_col}"
-                )
-            lines.append("")
-
-        lines.append(_format_summary(traces, grouped))
-        return "\n".join(lines)
-
-    def format_json_report(self, traces):
-        return json.dumps([asdict(t) for t in traces], indent=2, default=str)
+def format_json_report(traces):
+    return json.dumps([asdict(t) for t in traces], indent=2, default=str)
 
 
 # ── Utilities ─────────────────────────────────────────────────────
 
-def get_original_email_address(email):
+def _get_original_email_address(email):
     if not email or "+" not in email.split("@")[0]:
         return email
     local, domain = email.split("@")
     original_local = local.split("+")[0]
     return f"{original_local}@{domain}"
-
-
-def _get_ocm_token():
-    import os
-    return os.environ.get("OCM_TOKEN", "")
 
 
 def _prunability_tag(group):
@@ -630,26 +595,41 @@ def main():
         real_stdout = sys.stdout
         sys.stdout = sys.stderr
 
-    tracer = ResourceTracer(
-        region=args.region,
-        ocm_accounts=args.ocm_accounts.split(","),
-        skip_ocm=args.skip_ocm,
-    )
+    try:
+        ec2_client = boto3.Session(region_name=args.region).client("ec2")
+    except NoCredentialsError:
+        print("Error: AWS credentials not found.")
+        sys.exit(1)
 
-    traces = tracer.trace(
-        resource_ids=args.resource_ids or None,
-        states=args.states.split(",") if args.scan else None,
-        scan=args.scan,
-    )
+    skip_ocm = args.skip_ocm
+    ocm_accounts = args.ocm_accounts.split(",")
 
-    tracer.classify_prunability(traces, age_threshold=args.age_threshold)
-    traces = tracer.filter_traces(traces, args.filter)
+    if args.scan:
+        state_list = args.states.split(",")
+        print(f"Scanning {args.region} for instances in states: {', '.join(state_list)}")
+        instances = fetch_ec2_instances(ec2_client, states=state_list)
+    else:
+        instances = fetch_ec2_instances(ec2_client, instance_ids=args.resource_ids)
+
+    print(f"Found {len(instances)} instances")
+    traces = [classify_ec2_instance(i) for i in instances]
+
+    ocm_clusters = {}
+    owner_cache = {}
+    if not skip_ocm:
+        print("Loading OCM cluster data...")
+        ocm_clusters = load_ocm_clusters(ocm_accounts)
+        print(f"Loaded {len(ocm_clusters) // 2} clusters from OCM")
+        enrich_with_ocm(traces, ocm_clusters, owner_cache)
+
+    classify_prunability(traces, ocm_clusters, age_threshold=args.age_threshold)
+    traces = filter_traces(traces, args.filter)
 
     if json_mode:
         sys.stdout = real_stdout
-        print(tracer.format_json_report(traces))
+        print(format_json_report(traces))
     else:
-        print(tracer.format_text_report(traces))
+        print(format_text_report(traces, args.region))
 
 
 if __name__ == "__main__":

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -2,8 +2,8 @@
 AWS Resource Tracer
 
 Read-only inspection tool that traces AWS resources back to their OpenShift
-clusters and identifies who provisioned them. Supports EC2 instances and
-NAT gateways.
+clusters and identifies who provisioned them. Supports EC2 instances,
+NAT gateways, and VPC endpoints.
 
 Usage:
   python src/resource_tracer.py i-01d154018d489351c --region us-east-1
@@ -27,11 +27,13 @@ from botocore.exceptions import ClientError, NoCredentialsError
 RESOURCE_TYPE_LABELS = {
     "ec2": "EC2 Instances",
     "nat-gateway": "NAT Gateways",
+    "vpc-endpoint": "VPC Endpoints",
 }
 
 DEFAULT_STATES = {
     "ec2": "running,stopped",
     "nat-gateway": "available,failed",
+    "vpc-endpoint": "available,pending",
 }
 
 
@@ -110,6 +112,29 @@ def fetch_nat_gateways(ec2_client, nat_gateway_ids=None, states=None):
         print(f"Error fetching NAT gateways: {e}")
 
     return gateways
+
+
+def fetch_vpc_endpoints(ec2_client, endpoint_ids=None, states=None):
+    endpoints = []
+    paginator = ec2_client.get_paginator("describe_vpc_endpoints")
+
+    try:
+        if endpoint_ids:
+            pages = paginator.paginate(VpcEndpointIds=endpoint_ids)
+        elif states:
+            pages = paginator.paginate(
+                Filters=[{"Name": "vpc-endpoint-state", "Values": states}]
+            )
+        else:
+            pages = paginator.paginate()
+
+        for page in pages:
+            endpoints.extend(page["VpcEndpoints"])
+
+    except ClientError as e:
+        print(f"Error fetching VPC endpoints: {e}")
+
+    return endpoints
 
 
 # ── Tag helpers ───────────────────────────────────────────────
@@ -243,6 +268,22 @@ def classify_nat_gateway(nat_gw):
         resource_id=nat_gw["NatGatewayId"],
         resource_type="nat-gateway",
         state=nat_gw.get("State", ""),
+        name=tags.get("Name", ""),
+        launch_time=create_time.isoformat() if create_time else "",
+        age_str=_format_age(create_time),
+        tags=tags,
+    )
+    return _classify_by_tags(tags, trace)
+
+
+def classify_vpc_endpoint(endpoint):
+    tags = _tags_to_dict(endpoint)
+    create_time = endpoint.get("CreationTimestamp")
+
+    trace = ResourceTrace(
+        resource_id=endpoint["VpcEndpointId"],
+        resource_type="vpc-endpoint",
+        state=endpoint.get("State", ""),
         name=tags.get("Name", ""),
         launch_time=create_time.isoformat() if create_time else "",
         age_str=_format_age(create_time),
@@ -604,7 +645,7 @@ def parse_args():
         help="AWS region (default: us-east-1)"
     )
     parser.add_argument(
-        "--resource-type", default="ec2", choices=["ec2", "nat-gateway"],
+        "--resource-type", default="ec2", choices=["ec2", "nat-gateway", "vpc-endpoint"],
         help="Resource type to trace (default: ec2)"
     )
     parser.add_argument(
@@ -613,7 +654,7 @@ def parse_args():
     )
     parser.add_argument(
         "--states", default=None,
-        help="Comma-separated states for --scan (default: running,stopped for EC2; available,failed for NAT gateways)"
+        help="Comma-separated states for --scan (default depends on resource type)"
     )
     parser.add_argument(
         "--ocm-accounts", default="PROD,STAGE",
@@ -679,6 +720,15 @@ def main():
             resources = fetch_nat_gateways(ec2_client, nat_gateway_ids=args.resource_ids)
         print(f"Found {len(resources)} NAT gateways")
         traces = [classify_nat_gateway(r) for r in resources]
+
+    elif resource_type == "vpc-endpoint":
+        if args.scan:
+            print(f"Scanning {args.region} for VPC endpoints in states: {', '.join(state_list)}")
+            resources = fetch_vpc_endpoints(ec2_client, states=state_list)
+        else:
+            resources = fetch_vpc_endpoints(ec2_client, endpoint_ids=args.resource_ids)
+        print(f"Found {len(resources)} VPC endpoints")
+        traces = [classify_vpc_endpoint(r) for r in resources]
 
     ocm_clusters = {}
     owner_cache = {}

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -492,7 +492,9 @@ def group_by_cluster(traces):
 
 # ── Text report ───────────────────────────────────────────────
 
-def format_text_report(traces, region, resource_types=None):
+def format_text_report(traces, region, resource_types=None, all_traces=None):
+    if all_traces is None:
+        all_traces = traces
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     if resource_types is None:
         resource_types = list(RESOURCE_TYPE_LABELS.keys())
@@ -502,7 +504,11 @@ def format_text_report(traces, region, resource_types=None):
     lines = []
     lines.append(f"AWS Resource Tracer — {region} ({rt_label})")
     lines.append("=" * 60)
-    lines.append(f"Scanned: {len(traces)} resources | {now_str}")
+    scanned_label = f"Scanned: {len(all_traces)} resources"
+    if len(traces) != len(all_traces):
+        scanned_label += f" | Showing: {len(traces)}"
+    scanned_label += f" | {now_str}"
+    lines.append(scanned_label)
     lines.append("")
 
     grouped = group_by_cluster(traces)
@@ -551,7 +557,7 @@ def format_text_report(traces, region, resource_types=None):
             )
         lines.append("")
 
-    lines.append(_format_summary(traces, grouped))
+    lines.append(_format_summary(traces, grouped, all_traces))
     return "\n".join(lines)
 
 
@@ -593,7 +599,9 @@ def _type_label(cluster_type):
     return labels.get(cluster_type, cluster_type)
 
 
-def _format_summary(traces, grouped):
+def _format_summary(traces, grouped, all_traces=None):
+    if all_traces is None:
+        all_traces = traces
     lines = ["=" * 60, "Summary", "=" * 60]
 
     type_counts = defaultdict(lambda: {"resources": 0, "clusters": set(), "expired_clusters": set()})
@@ -619,17 +627,14 @@ def _format_summary(traces, grouped):
             f"({len(tc['clusters'])} clusters{expired_note})"
         )
 
-    prunable_count = sum(1 for t in traces if t.prunability == "prunable")
-    questionable_count = sum(1 for t in traces if t.prunability == "questionable")
-    if prunable_count or questionable_count:
-        lines.append("")
-        lines.append("Prunability:")
-        if prunable_count:
-            lines.append(f"  Prunable:        {prunable_count:>4} resources")
-        if questionable_count:
-            lines.append(f"  Questionable:    {questionable_count:>4} resources")
-        not_prunable = len(traces) - prunable_count - questionable_count
-        lines.append(f"  Not prunable:    {not_prunable:>4} resources")
+    prunable_count = sum(1 for t in all_traces if t.prunability == "prunable")
+    questionable_count = sum(1 for t in all_traces if t.prunability == "questionable")
+    not_prunable = len(all_traces) - prunable_count - questionable_count
+    lines.append("")
+    lines.append("Prunability (all scanned):")
+    lines.append(f"  Prunable:        {prunable_count:>4} resources")
+    lines.append(f"  Questionable:    {questionable_count:>4} resources")
+    lines.append(f"  Not prunable:    {not_prunable:>4} resources")
 
     return "\n".join(lines)
 
@@ -745,13 +750,14 @@ def main():
         enrich_with_ocm(traces, ocm_clusters, owner_cache)
 
     classify_prunability(traces, ocm_clusters, age_threshold=args.age_threshold)
+    all_traces = traces
     traces = filter_traces(traces, args.filter)
 
     if json_mode:
         sys.stdout = real_stdout
         print(format_json_report(traces))
     else:
-        print(format_text_report(traces, args.region, resource_types))
+        print(format_text_report(traces, args.region, resource_types, all_traces))
 
 
 if __name__ == "__main__":

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -492,9 +492,13 @@ def group_by_cluster(traces):
 
 # ── Text report ───────────────────────────────────────────────
 
-def format_text_report(traces, region, resource_type="ec2"):
+def format_text_report(traces, region, resource_types=None):
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    rt_label = RESOURCE_TYPE_LABELS.get(resource_type, resource_type)
+    if resource_types is None:
+        resource_types = list(RESOURCE_TYPE_LABELS.keys())
+    if isinstance(resource_types, str):
+        resource_types = [resource_types]
+    rt_label = ", ".join(RESOURCE_TYPE_LABELS.get(rt, rt) for rt in resource_types)
     lines = []
     lines.append(f"AWS Resource Tracer — {region} ({rt_label})")
     lines.append("=" * 60)
@@ -644,9 +648,10 @@ def parse_args():
         "--region", default="us-east-1",
         help="AWS region (default: us-east-1)"
     )
+    all_types = ",".join(RESOURCE_TYPE_LABELS.keys())
     parser.add_argument(
-        "--resource-type", default="ec2", choices=["ec2", "nat-gateway", "vpc-endpoint"],
-        help="Resource type to trace (default: ec2)"
+        "--resource-type", default=all_types,
+        help=f"Comma-separated resource types to trace (default: {all_types})"
     )
     parser.add_argument(
         "--scan", action="store_true",
@@ -700,35 +705,36 @@ def main():
 
     skip_ocm = args.skip_ocm
     ocm_accounts = args.ocm_accounts.split(",")
-    resource_type = args.resource_type
-    state_list = (args.states or DEFAULT_STATES[resource_type]).split(",")
+    resource_types = args.resource_type.split(",")
 
-    if resource_type == "ec2":
-        if args.scan:
-            print(f"Scanning {args.region} for EC2 instances in states: {', '.join(state_list)}")
-            resources = fetch_ec2_instances(ec2_client, states=state_list)
-        else:
-            resources = fetch_ec2_instances(ec2_client, instance_ids=args.resource_ids)
-        print(f"Found {len(resources)} instances")
-        traces = [classify_ec2_instance(r) for r in resources]
+    for rt in resource_types:
+        if rt not in RESOURCE_TYPE_LABELS:
+            print(f"Error: unknown resource type '{rt}'. Valid types: {', '.join(RESOURCE_TYPE_LABELS.keys())}")
+            sys.exit(1)
 
-    elif resource_type == "nat-gateway":
-        if args.scan:
-            print(f"Scanning {args.region} for NAT gateways in states: {', '.join(state_list)}")
-            resources = fetch_nat_gateways(ec2_client, states=state_list)
-        else:
-            resources = fetch_nat_gateways(ec2_client, nat_gateway_ids=args.resource_ids)
-        print(f"Found {len(resources)} NAT gateways")
-        traces = [classify_nat_gateway(r) for r in resources]
+    if not args.scan and len(resource_types) > 1:
+        print("Error: specify a single --resource-type when passing resource IDs")
+        sys.exit(1)
 
-    elif resource_type == "vpc-endpoint":
+    traces = []
+
+    fetch_classify = {
+        "ec2": (fetch_ec2_instances, classify_ec2_instance, "instances"),
+        "nat-gateway": (fetch_nat_gateways, classify_nat_gateway, "NAT gateways"),
+        "vpc-endpoint": (fetch_vpc_endpoints, classify_vpc_endpoint, "VPC endpoints"),
+    }
+
+    for rt in resource_types:
+        fetch_fn, classify_fn, label = fetch_classify[rt]
+        state_list = (args.states or DEFAULT_STATES[rt]).split(",")
+
         if args.scan:
-            print(f"Scanning {args.region} for VPC endpoints in states: {', '.join(state_list)}")
-            resources = fetch_vpc_endpoints(ec2_client, states=state_list)
+            print(f"Scanning {args.region} for {label} in states: {', '.join(state_list)}")
+            resources = fetch_fn(ec2_client, states=state_list)
         else:
-            resources = fetch_vpc_endpoints(ec2_client, endpoint_ids=args.resource_ids)
-        print(f"Found {len(resources)} VPC endpoints")
-        traces = [classify_vpc_endpoint(r) for r in resources]
+            resources = fetch_fn(ec2_client, args.resource_ids)
+        print(f"Found {len(resources)} {label}")
+        traces.extend(classify_fn(r) for r in resources)
 
     ocm_clusters = {}
     owner_cache = {}
@@ -745,7 +751,7 @@ def main():
         sys.stdout = real_stdout
         print(format_json_report(traces))
     else:
-        print(format_text_report(traces, args.region, resource_type))
+        print(format_text_report(traces, args.region, resource_types))
 
 
 if __name__ == "__main__":

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -625,6 +625,11 @@ def main():
         print("Error: provide resource IDs or use --scan")
         sys.exit(1)
 
+    json_mode = args.output == "json"
+    if json_mode:
+        real_stdout = sys.stdout
+        sys.stdout = sys.stderr
+
     tracer = ResourceTracer(
         region=args.region,
         ocm_accounts=args.ocm_accounts.split(","),
@@ -640,7 +645,8 @@ def main():
     tracer.classify_prunability(traces, age_threshold=args.age_threshold)
     traces = tracer.filter_traces(traces, args.filter)
 
-    if args.output == "json":
+    if json_mode:
+        sys.stdout = real_stdout
         print(tracer.format_json_report(traces))
     else:
         print(tracer.format_text_report(traces))

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -1,0 +1,650 @@
+"""
+AWS Resource Tracer
+
+Read-only inspection tool that traces AWS resources back to their OpenShift
+clusters and identifies who provisioned them. Currently supports EC2 instances.
+
+Usage:
+  python src/resource_tracer.py i-01d154018d489351c --region us-east-1
+  python src/resource_tracer.py --scan --region us-east-1
+  python src/resource_tracer.py --scan --region us-west-2 --skip-ocm
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from dataclasses import dataclass, field, asdict
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+
+@dataclass
+class ResourceTrace:
+    resource_id: str
+    resource_type: str
+    instance_type: str = ""
+    state: str = ""
+    name: str = ""
+    launch_time: str = ""
+    age_str: str = ""
+    cluster_name: str = ""
+    cluster_type: str = "unknown"
+    cluster_id: str = ""
+    owner_name: str = ""
+    owner_email: str = ""
+    ocm_account: str = ""
+    expiration_date: str = ""
+    is_expired: bool = False
+    expired_ago: str = ""
+    prow_job: str = ""
+    prow_build_id: str = ""
+    prunability: str = ""
+    tags: dict = field(default_factory=dict)
+
+
+class ResourceTracer:
+    def __init__(self, region="us-east-1", ocm_accounts=None, skip_ocm=False):
+        self.region = region
+        self.ocm_accounts = ocm_accounts or ["PROD", "STAGE"]
+        self.skip_ocm = skip_ocm
+        self.ocm_clusters = {}
+        self.owner_cache = {}
+
+        try:
+            self.session = boto3.Session(region_name=region)
+            self.ec2_client = self.session.client("ec2")
+        except NoCredentialsError:
+            print("Error: AWS credentials not found.")
+            sys.exit(1)
+
+    # ── EC2 fetching ──────────────────────────────────────────────
+
+    def fetch_ec2_instances(self, instance_ids=None, states=None):
+        instances = []
+        paginator = self.ec2_client.get_paginator("describe_instances")
+
+        try:
+            if instance_ids:
+                pages = paginator.paginate(InstanceIds=instance_ids)
+            elif states:
+                pages = paginator.paginate(
+                    Filters=[{"Name": "instance-state-name", "Values": states}]
+                )
+            else:
+                pages = paginator.paginate()
+
+            for page in pages:
+                for reservation in page["Reservations"]:
+                    instances.extend(reservation["Instances"])
+
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "InvalidInstanceID.NotFound":
+                print(f"Warning: {e.response['Error']['Message']}")
+            else:
+                print(f"Error fetching instances: {e}")
+
+        return instances
+
+    # ── Tag helpers ───────────────────────────────────────────────
+
+    def _tags_to_dict(self, instance):
+        return {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+
+    def _get_kubernetes_cluster_name(self, tags):
+        for key, value in tags.items():
+            if key.startswith("kubernetes.io/cluster/") and value == "owned":
+                return key.split("kubernetes.io/cluster/")[1]
+        return None
+
+    def _parse_expiration(self, tags):
+        raw = tags.get("expirationDate")
+        if not raw:
+            return None, False
+        try:
+            dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            now = datetime.now(timezone.utc)
+            return dt, now > dt
+        except (ValueError, TypeError):
+            return None, False
+
+    def _format_age(self, dt):
+        if not dt:
+            return ""
+        if isinstance(dt, str):
+            try:
+                dt = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                return ""
+        now = datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = now - dt
+        days = delta.days
+        hours = delta.seconds // 3600
+        if days > 0:
+            return f"{days}d {hours}h"
+        return f"{hours}h"
+
+    # ── Classification ────────────────────────────────────────────
+
+    def classify_ec2_instance(self, instance):
+        tags = self._tags_to_dict(instance)
+        k8s_cluster = self._get_kubernetes_cluster_name(tags)
+        exp_dt, is_expired = self._parse_expiration(tags)
+        launch_time = instance.get("LaunchTime")
+
+        trace = ResourceTrace(
+            resource_id=instance["InstanceId"],
+            resource_type="ec2",
+            instance_type=instance.get("InstanceType", ""),
+            state=instance.get("State", {}).get("Name", ""),
+            name=tags.get("Name", ""),
+            launch_time=launch_time.isoformat() if launch_time else "",
+            age_str=self._format_age(launch_time),
+            tags=tags,
+        )
+
+        if exp_dt:
+            trace.expiration_date = exp_dt.isoformat()
+            trace.is_expired = is_expired
+            if is_expired:
+                trace.expired_ago = self._format_age(exp_dt)
+
+        # 1. Prow CI
+        if "prow.k8s.io/build-id" in tags and "prow.k8s.io/job" in tags:
+            trace.cluster_type = "prow-ci"
+            trace.prow_job = tags["prow.k8s.io/job"]
+            trace.prow_build_id = tags["prow.k8s.io/build-id"]
+            trace.cluster_name = k8s_cluster or ""
+            return trace
+
+        # 2. ROSA HCP — has api.openshift.com/name
+        if "api.openshift.com/name" in tags:
+            trace.cluster_name = tags["api.openshift.com/name"]
+            trace.cluster_id = tags.get("api.openshift.com/id", "")
+            clustertype = tags.get("red-hat-clustertype", "")
+            if clustertype == "osd":
+                trace.cluster_type = "osd-hcp"
+            else:
+                trace.cluster_type = "rosa-hcp"
+            return trace
+
+        # 3. ROSA Classic / OSD — has red-hat-clustertype but no api.openshift.com/name
+        if "red-hat-clustertype" in tags:
+            clustertype = tags["red-hat-clustertype"]
+            trace.cluster_type = "rosa-classic" if clustertype == "rosa" else "osd"
+            trace.cluster_id = tags.get("api.openshift.com/id", "")
+            trace.cluster_name = k8s_cluster or ""
+            return trace
+
+        # 4. IPI — has kubernetes.io/cluster/* with owned
+        if k8s_cluster:
+            trace.cluster_type = "ipi"
+            trace.cluster_name = k8s_cluster
+            return trace
+
+        # 5. Unknown
+        trace.cluster_type = "unknown"
+        return trace
+
+    # ── OCM integration ──────────────────────────────────────────
+
+    def load_ocm_clusters(self):
+        if self.skip_ocm:
+            return
+
+        for account in self.ocm_accounts:
+            if self._ocm_login(account):
+                clusters = self._ocm_list_clusters(account)
+                self.ocm_clusters.update(clusters)
+
+    def _ocm_login(self, account):
+        token = _get_ocm_token()
+        if not token:
+            # No token set — try using whatever session is already active
+            result = subprocess.run(
+                ["ocm", "whoami"], capture_output=True, text=True,
+            )
+            if result.returncode == 0:
+                return True
+            print(f"Warning: OCM_TOKEN not set and no active session for {account}")
+            return False
+
+        cmd = ["ocm", "login", "--token", token]
+        if account == "STAGE":
+            cmd.extend(["--url", "stage"])
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"Warning: OCM login failed for {account}: {result.stderr.strip()}")
+            return False
+        return True
+
+    def _ocm_list_clusters(self, account):
+        clusters = {}
+        page = 1
+        page_size = 100
+
+        while True:
+            result = subprocess.run(
+                ["ocm", "get", "/api/clusters_mgmt/v1/clusters",
+                 "--parameter", f"page={page}",
+                 "--parameter", f"size={page_size}"],
+                capture_output=True, text=True,
+            )
+            if result.returncode != 0:
+                print(f"Warning: Could not list OCM clusters ({account}): {result.stderr.strip()}")
+                return clusters
+
+            try:
+                data = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                print(f"Warning: Invalid JSON from OCM cluster list ({account})")
+                return clusters
+
+            for item in data.get("items", []):
+                cluster_id = item.get("id", "")
+                name = item.get("name", "")
+                entry = {
+                    "id": cluster_id,
+                    "name": name,
+                    "type": item.get("product", {}).get("id", ""),
+                    "hcp": str(item.get("hypershift", {}).get("enabled", False)).lower(),
+                    "region": item.get("region", {}).get("id", ""),
+                    "status": item.get("state", ""),
+                    "ocm_account": account,
+                }
+                clusters[name] = entry
+                clusters[cluster_id] = entry
+
+            total = data.get("total", 0)
+            if page * page_size >= total:
+                break
+            page += 1
+
+        return clusters
+
+    def lookup_cluster_owner(self, cluster_id, ocm_account):
+        if cluster_id in self.owner_cache:
+            return self.owner_cache[cluster_id]
+
+        result = subprocess.run(
+            ["ocm", "get", "/api/accounts_mgmt/v1/subscriptions",
+             "-p", f"search=cluster_id='{cluster_id}'",
+             "--parameter", "fetchAccounts=true"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            self.owner_cache[cluster_id] = ("", "")
+            return ("", "")
+
+        try:
+            data = json.loads(result.stdout)
+            items = data.get("items", [])
+            if not items:
+                self.owner_cache[cluster_id] = ("", "")
+                return ("", "")
+            creator = items[0].get("creator", {})
+            name = creator.get("name", "") or \
+                f"{creator.get('first_name', '')} {creator.get('last_name', '')}".strip()
+            email = get_original_email_address(creator.get("email", ""))
+            self.owner_cache[cluster_id] = (name, email)
+            return (name, email)
+        except (json.JSONDecodeError, KeyError, IndexError):
+            self.owner_cache[cluster_id] = ("", "")
+            return ("", "")
+
+    def enrich_with_ocm(self, traces):
+        if self.skip_ocm:
+            return
+
+        # Group clusters by OCM account so we login once per account
+        by_account = defaultdict(dict)
+        for trace in traces:
+            if trace.cluster_type in ("unknown", "prow-ci"):
+                continue
+            ocm_entry = (
+                self.ocm_clusters.get(trace.cluster_name)
+                or self.ocm_clusters.get(trace.cluster_id)
+            )
+            if ocm_entry:
+                trace.ocm_account = ocm_entry["ocm_account"]
+                cid = ocm_entry["id"]
+                trace.cluster_id = cid
+                account = ocm_entry["ocm_account"]
+                if cid not in by_account[account]:
+                    by_account[account][cid] = []
+                by_account[account][cid].append(trace)
+
+        for account, cluster_map in by_account.items():
+            if not self._ocm_login(account):
+                continue
+            for cluster_id, group_traces in cluster_map.items():
+                owner_name, owner_email = self.lookup_cluster_owner(cluster_id, account)
+                for t in group_traces:
+                    t.owner_name = owner_name
+                    t.owner_email = owner_email
+
+    # ── Prunability ────────────────────────────────────────────────
+
+    def classify_prunability(self, traces, age_threshold=30):
+        now = datetime.now(timezone.utc)
+        managed_types = {"rosa-hcp", "rosa-classic", "osd", "osd-hcp", "ipi"}
+
+        for trace in traces:
+            age_days = self._age_days(trace.launch_time, now)
+
+            if trace.cluster_type == "prow-ci":
+                if trace.is_expired:
+                    trace.prunability = "prunable"
+                elif not trace.expiration_date:
+                    trace.prunability = "questionable"
+                else:
+                    trace.prunability = "not-prunable"
+
+            elif trace.cluster_type in managed_types:
+                ocm_entry = (
+                    self.ocm_clusters.get(trace.cluster_name)
+                    or self.ocm_clusters.get(trace.cluster_id)
+                )
+                ocm_status = ocm_entry["status"] if ocm_entry else ""
+                if ocm_status == "error":
+                    trace.prunability = "questionable"
+                elif age_days >= age_threshold:
+                    trace.prunability = "questionable"
+                else:
+                    trace.prunability = "not-prunable"
+
+            elif trace.cluster_type == "unknown":
+                if age_days >= age_threshold:
+                    trace.prunability = "questionable"
+                else:
+                    trace.prunability = "not-prunable"
+
+            else:
+                trace.prunability = "not-prunable"
+
+    def _age_days(self, launch_time_str, now):
+        if not launch_time_str:
+            return 0
+        try:
+            dt = datetime.fromisoformat(launch_time_str.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return (now - dt).days
+        except (ValueError, TypeError):
+            return 0
+
+    @staticmethod
+    def filter_traces(traces, filter_value):
+        if not filter_value:
+            return traces
+        allowed = set(filter_value.split("+"))
+        return [t for t in traces if t.prunability in allowed]
+
+    # ── Orchestration ─────────────────────────────────────────────
+
+    def trace(self, resource_ids=None, states=None, scan=False):
+        if scan:
+            state_list = states or ["running", "stopped"]
+            print(f"Scanning {self.region} for instances in states: {', '.join(state_list)}")
+            instances = self.fetch_ec2_instances(states=state_list)
+        elif resource_ids:
+            instances = self.fetch_ec2_instances(instance_ids=resource_ids)
+        else:
+            print("Error: provide instance IDs or use --scan")
+            sys.exit(1)
+
+        print(f"Found {len(instances)} instances")
+
+        traces = [self.classify_ec2_instance(i) for i in instances]
+
+        if not self.skip_ocm:
+            print("Loading OCM cluster data...")
+            self.load_ocm_clusters()
+            print(f"Loaded {len(self.ocm_clusters) // 2} clusters from OCM")
+            self.enrich_with_ocm(traces)
+
+        return traces
+
+    # ── Grouping ──────────────────────────────────────────────────
+
+    def group_by_cluster(self, traces):
+        groups = defaultdict(list)
+        for t in traces:
+            key = (t.cluster_name or t.resource_id, t.cluster_type)
+            groups[key].append(t)
+
+        type_order = {
+            "rosa-hcp": 0, "rosa-classic": 1, "osd": 2, "osd-hcp": 3,
+            "ipi": 4, "prow-ci": 5, "unknown": 6,
+        }
+        return sorted(groups.items(), key=lambda x: (type_order.get(x[0][1], 99), x[0][0]))
+
+    # ── Text report ───────────────────────────────────────────────
+
+    def format_text_report(self, traces):
+        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        lines = []
+        lines.append(f"AWS Resource Tracer — {self.region} (EC2 Instances)")
+        lines.append("=" * 60)
+        lines.append(f"Scanned: {len(traces)} instances | {now_str}")
+        lines.append("")
+
+        grouped = self.group_by_cluster(traces)
+
+        for (cluster_name, cluster_type), group in grouped:
+            sample = group[0]
+
+            if cluster_type == "unknown":
+                label = "Unassociated"
+            else:
+                label = f"{cluster_name} ({_type_label(cluster_type)})"
+
+            prunability_tag = _prunability_tag(group)
+            if prunability_tag:
+                label += f" {prunability_tag}"
+
+            lines.append(f"── {label} " + "─" * max(1, 58 - len(label)))
+
+            if sample.owner_name or sample.owner_email:
+                owner = sample.owner_name
+                if sample.owner_email:
+                    owner += f" <{sample.owner_email}>"
+                ocm = f" | OCM: {sample.ocm_account}" if sample.ocm_account else ""
+                lines.append(f"   Owner: {owner}{ocm}")
+
+            if cluster_type == "prow-ci" and sample.prow_job:
+                lines.append(f"   Job: {sample.prow_job}")
+                lines.append(f"   Build: {sample.prow_build_id}")
+
+            if sample.expiration_date:
+                exp_status = f"expired {sample.expired_ago} ago" if sample.is_expired else "active"
+                lines.append(f"   Expiration: {sample.expiration_date} ({exp_status})")
+
+            if sample.cluster_id:
+                lines.append(f"   Cluster ID: {sample.cluster_id}")
+
+            lines.append("")
+            lines.append(
+                f"   {'INSTANCE':<24} {'TYPE':<14} {'STATE':<10} {'LAUNCHED':<13} {'AGE':<8} {'NAME'}"
+            )
+            for t in sorted(group, key=lambda x: x.resource_id):
+                launched = t.launch_time[:10] if t.launch_time else ""
+                name_col = t.name if cluster_type == "unknown" else ""
+                lines.append(
+                    f"   {t.resource_id:<24} {t.instance_type:<14} {t.state:<10} {launched:<13} {t.age_str:<8} {name_col}"
+                )
+            lines.append("")
+
+        lines.append(_format_summary(traces, grouped))
+        return "\n".join(lines)
+
+    def format_json_report(self, traces):
+        return json.dumps([asdict(t) for t in traces], indent=2, default=str)
+
+
+# ── Utilities ─────────────────────────────────────────────────────
+
+def get_original_email_address(email):
+    if not email or "+" not in email.split("@")[0]:
+        return email
+    local, domain = email.split("@")
+    original_local = local.split("+")[0]
+    return f"{original_local}@{domain}"
+
+
+def _get_ocm_token():
+    import os
+    return os.environ.get("OCM_TOKEN", "")
+
+
+def _prunability_tag(group):
+    prunabilities = {t.prunability for t in group if t.prunability}
+    if not prunabilities:
+        return ""
+    if "prunable" in prunabilities:
+        return "[PRUNABLE]"
+    if "questionable" in prunabilities:
+        return "[QUESTIONABLE]"
+    return ""
+
+
+def _type_label(cluster_type):
+    labels = {
+        "rosa-hcp": "ROSA HCP",
+        "rosa-classic": "ROSA Classic",
+        "osd": "OSD",
+        "osd-hcp": "OSD HCP",
+        "ipi": "IPI",
+        "prow-ci": "Prow CI",
+        "unknown": "Unknown",
+    }
+    return labels.get(cluster_type, cluster_type)
+
+
+def _format_summary(traces, grouped):
+    lines = ["=" * 60, "Summary", "=" * 60]
+
+    type_counts = defaultdict(lambda: {"instances": 0, "clusters": set(), "expired_clusters": set()})
+    for (cluster_name, cluster_type), group in grouped:
+        tc = type_counts[cluster_type]
+        tc["instances"] += len(group)
+        tc["clusters"].add(cluster_name)
+        if any(t.is_expired for t in group):
+            tc["expired_clusters"].add(cluster_name)
+
+    lines.append(f"Total: {len(traces)} instances, {sum(len(tc['clusters']) for tc in type_counts.values())} clusters")
+    lines.append("")
+
+    for ct in ["rosa-hcp", "rosa-classic", "osd", "osd-hcp", "ipi", "prow-ci", "unknown"]:
+        tc = type_counts.get(ct)
+        if not tc or tc["instances"] == 0:
+            continue
+        expired_note = ""
+        if tc["expired_clusters"]:
+            expired_note = f", {len(tc['expired_clusters'])} expired"
+        lines.append(
+            f"  {_type_label(ct):<15} {tc['instances']:>4} instances  "
+            f"({len(tc['clusters'])} clusters{expired_note})"
+        )
+
+    prunable_count = sum(1 for t in traces if t.prunability == "prunable")
+    questionable_count = sum(1 for t in traces if t.prunability == "questionable")
+    if prunable_count or questionable_count:
+        lines.append("")
+        lines.append("Prunability:")
+        if prunable_count:
+            lines.append(f"  Prunable:        {prunable_count:>4} instances")
+        if questionable_count:
+            lines.append(f"  Questionable:    {questionable_count:>4} instances")
+        not_prunable = len(traces) - prunable_count - questionable_count
+        lines.append(f"  Not prunable:    {not_prunable:>4} instances")
+
+    return "\n".join(lines)
+
+
+# ── CLI ───────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="AWS Resource Tracer — trace resources to clusters and owners (read-only)"
+    )
+    parser.add_argument(
+        "resource_ids", nargs="*",
+        help="Resource IDs to trace (e.g., EC2 instance IDs)"
+    )
+    parser.add_argument(
+        "--region", default="us-east-1",
+        help="AWS region (default: us-east-1)"
+    )
+    parser.add_argument(
+        "--resource-type", default="ec2", choices=["ec2"],
+        help="Resource type to trace (default: ec2)"
+    )
+    parser.add_argument(
+        "--scan", action="store_true",
+        help="Scan all resources of the given type in the region"
+    )
+    parser.add_argument(
+        "--states", default="running,stopped",
+        help="Comma-separated instance states for --scan (default: running,stopped)"
+    )
+    parser.add_argument(
+        "--ocm-accounts", default="PROD,STAGE",
+        help="Comma-separated OCM accounts to query (default: PROD,STAGE)"
+    )
+    parser.add_argument(
+        "--skip-ocm", action="store_true",
+        help="Skip OCM lookups"
+    )
+    parser.add_argument(
+        "--output", default="text", choices=["text", "json"],
+        help="Output format (default: text)"
+    )
+    parser.add_argument(
+        "--filter", default=None,
+        choices=["prunable", "questionable", "prunable+questionable", "not-prunable"],
+        help="Filter output by prunability category"
+    )
+    parser.add_argument(
+        "--age-threshold", type=int, default=30,
+        help="Days after which a resource is considered questionably prunable (default: 30)"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not args.scan and not args.resource_ids:
+        print("Error: provide resource IDs or use --scan")
+        sys.exit(1)
+
+    tracer = ResourceTracer(
+        region=args.region,
+        ocm_accounts=args.ocm_accounts.split(","),
+        skip_ocm=args.skip_ocm,
+    )
+
+    traces = tracer.trace(
+        resource_ids=args.resource_ids or None,
+        states=args.states.split(",") if args.scan else None,
+        scan=args.scan,
+    )
+
+    tracer.classify_prunability(traces, age_threshold=args.age_threshold)
+    traces = tracer.filter_traces(traces, args.filter)
+
+    if args.output == "json":
+        print(tracer.format_json_report(traces))
+    else:
+        print(tracer.format_text_report(traces))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/resource_tracer.py
+++ b/src/resource_tracer.py
@@ -206,7 +206,7 @@ def _classify_by_tags(tags, trace):
             trace.expired_ago = _format_age(exp_dt)
 
     # 1. Prow CI
-    if "prow.k8s.io/build-id" in tags and "prow.k8s.io/job" in tags:
+    if tags.get("prow.k8s.io/build-id") and tags.get("prow.k8s.io/job"):
         trace.cluster_type = "prow-ci"
         trace.prow_job = tags["prow.k8s.io/job"]
         trace.prow_build_id = tags["prow.k8s.io/build-id"]


### PR DESCRIPTION
## Summary

Adds two new tools for tracing and pruning AWS resources tied to OpenShift clusters:

- **`src/resource_tracer.py`** — Read-only tool that scans EC2 instances, NAT gateways, VPC endpoints, and Elastic IPs, traces them back to their OpenShift clusters (ROSA HCP, ROSA Classic, OSD, IPI, Prow CI) via tags, enriches with OCM data (cluster status, owner), and classifies prunability.
- **`src/resource_pruner.py`** — Deletes resources from tracer JSON output. Dry-run by default, requires explicit `--dry-run false`. Only accepts resources marked `prunable`; pass `--include-questionable` to also accept `questionable`.

### Resource types supported
- EC2 instances (batch termination)
- NAT gateways (one-at-a-time deletion)
- VPC endpoints (batch deletion, 25 per batch)
- Elastic IPs (disassociate if needed, then release)

### Prunability classification
- **Prunable**: Expired Prow CI resources
- **Questionable**: OCM error status, age > threshold, old prow CI without expiration, old unknown/untagged resources
- **Not prunable**: Everything else

### Pipeline usage
```bash
# Scan all resource types, filter prunable, dry-run delete
python src/resource_tracer.py --scan --region us-east-1 --filter prunable --output json | \
  python src/resource_pruner.py --region us-east-1 -

# Use jq to slice a subset
python src/resource_tracer.py --scan --region us-east-1 --filter prunable --output json | \
  jq '.[0:5]' | python src/resource_pruner.py --region us-east-1 --dry-run false -

# Scan specific resource types
python src/resource_tracer.py --scan --region us-east-1 --resource-type ec2,nat-gateway

# Include questionable resources in pruning
python src/resource_pruner.py --region us-east-1 --include-questionable --dry-run false prunable.json
```

### Safety features
- Dry-run by default in pruner
- Pruner rejects resources not marked prunable (or questionable with `--include-questionable`)
- Pruner validates required fields (resource_id, resource_type, state, prunability)
- Deduplicates resource IDs before sending to AWS
- Prow CI tag classification requires non-empty tag values
- Prunability summary always shows full scan counts, even when filtered
- Pruner delays output until stdin is fully read (clean pipeline output)
- Tracer is fully read-only — no mutations

### Jira
[RHOAIENG-62756](https://redhat.atlassian.net/browse/RHOAIENG-62756)