### PR TITLE
Fix: bug in worker_node_belongs_to_the_hcp_cluster function causing nodes to be not assigned to clusters

### DIFF
--- a/src/check_instances_status.py
+++ b/src/check_instances_status.py
@@ -52,7 +52,7 @@ def get_cluster_list(ocm_account:str):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/cluster_aggregator.py
+++ b/src/cluster_aggregator.py
@@ -236,7 +236,7 @@ def get_all_instances(ec2_instances, current_state):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/hibernate_cluster.py
+++ b/src/hibernate_cluster.py
@@ -73,7 +73,7 @@ def get_cluster_list(ocm_account:str):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/hibernate_clusters_daily.py
+++ b/src/hibernate_clusters_daily.py
@@ -44,7 +44,7 @@ def get_all_instances(ec2_instances, current_state):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/hibernate_clusters_weekend.py
+++ b/src/hibernate_clusters_weekend.py
@@ -69,7 +69,7 @@ def get_cluster_list(ocm_account:str):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/hibernate_untracked_clusters_during_shutdown.py
+++ b/src/hibernate_untracked_clusters_during_shutdown.py
@@ -44,7 +44,7 @@ def get_all_instances(ec2_instances, current_state):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/resume_cluster.py
+++ b/src/resume_cluster.py
@@ -74,7 +74,7 @@ def get_cluster_list(ocm_account:str):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/resume_clusters_daily.py
+++ b/src/resume_clusters_daily.py
@@ -49,7 +49,7 @@ def get_all_instances(ec2_instances, current_state):
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance: dict, cluster_name: str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result

--- a/src/resume_clusters_weekend.py
+++ b/src/resume_clusters_weekend.py
@@ -33,7 +33,7 @@ def get_last_hibernated():
 def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
     result = False
     for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+        if tag['Key'] == 'Name' and tag['Value'].startswith(f'{cluster_name}'):
             result = True
             break
     return result


### PR DESCRIPTION
The `cluster_name` in `worker_node_belongs_to_the_hcp_cluster` does not always align with the `api.openshift.com/name`- this causes EC2 instances to not be correlated with their clusters. This means EC2 instances in clusters with mismatching cluster_names and `api.openshiftt.com/name` were not being accounted for hibernate and resume operations. This likely is the underlying cause of [RHOAIENG-57466](https://redhat.atlassian.net/browse/RHOAIENG-57466)

This PR changes the logic to instead check if the EC2 instance name starts with the cluster name - this always matches all instances to their correct clusters. Verified by checking all clusters and ensuring that the new `worker_node_belongs_to_the_hcp_cluster` function correctly identifies all owned EC2 instances. 