### PR TITLE
Fix: Remove redundant and bugged cluster-association check for EC2 instances

### DIFF
--- a/src/hibernate_clusters_daily.py
+++ b/src/hibernate_clusters_daily.py
@@ -102,9 +102,8 @@ def run_command(command):
 
 def hybernate_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
     # ec2_map = ec2_instances[cluster.region]
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.name}-')]
     ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
+    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in ec2_map.keys() if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
     if len(InstanceIds) > 0:
         print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
         worker_count = len(InstanceIds)


### PR DESCRIPTION
The `worker_node_belongs_to_the_hcp_cluster` already handles instance-cluster association, and the previous check was erroneously assuming that instance names always are prefixed with the cluster name.  