### PR TITLE
Fix: Refactor all duplicated functions into common library functions

### DIFF
--- a/src/check_instances_status.py
+++ b/src/check_instances_status.py
@@ -1,109 +1,43 @@
 import json
-import time
 import requests
 import boto3
-import os
 import traceback
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
+import utils
+from utils import InstanceState
+
 def get_all_cluster_details(ocm_account:str, clusters:dict):
-    get_cluster_list(ocm_account)
+    utils.get_cluster_list(ocm_account)
     clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
     for cluster_detail in clusters_details:
-        clusters.append(oc_cluster(cluster_detail, ocm_account))
+        clusters.append(utils.OcCluster(cluster_detail, ocm_account))
     clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
 
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    # print(region, len(ec2_map))
-    return ec2_map
 
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def check_if_given_tag_exists(tag_name, volume):
-    result = False
-    if 'Tags' in volume:
-        tags = volume['Tags']
-        # print(tags)
-        for tag in tags:
-            if tag['Key'] == tag_name:
-                result = True
-                break
-    return result
-
-def delete_volume(volume_id, region):
-    ec2_client = boto3.client('ec2', region_name=region)
-    for attempt in range(7):
-        try:
-            ec2_client.delete_volume(VolumeId=volume_id)
-            print(f'Deleted the volume {volume_id}')
-        except:
-            time.sleep(5)
-
-def check_instance_status(cluster:oc_cluster, ec2_running_map:dict, ec2_stopped_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-    running_worker_nodes = [ec2_name for ec2_name in ec2_running_map]
-    InstanceIds_running = [ec2_running_map[worker_node]['InstanceId'] for worker_node in running_worker_nodes if
-                   worker_node_belongs_to_the_hcp_cluster(ec2_running_map[worker_node], cluster.name)]
-
-    stopped_worker_nodes = [ec2_name for ec2_name in ec2_stopped_map]
-    InstanceIds_stopped = [ec2_stopped_map[worker_node]['InstanceId'] for worker_node in stopped_worker_nodes if
-                   worker_node_belongs_to_the_hcp_cluster(ec2_stopped_map[worker_node], cluster.name)]
+def check_instance_status(cluster:utils.OcCluster, ec2_running_map:dict, ec2_stopped_map:dict):
+    InstanceIds_running = [ec2_running_map[worker_node]['InstanceId'] for worker_node in ec2_running_map if
+                   utils.worker_node_belongs_to_the_hcp_cluster(ec2_running_map[worker_node], cluster.name)]
+    InstanceIds_stopped = [ec2_stopped_map[worker_node]['InstanceId'] for worker_node in ec2_stopped_map if
+                   utils.worker_node_belongs_to_the_hcp_cluster(ec2_stopped_map[worker_node], cluster.name)]
 
     ec2_client = boto3.client('ec2', region_name=cluster.region)
 
-    # detach and delete the volumes
+    # detach and delete non-root volumes
+    root_devices = {inst['InstanceId']: inst['RootDeviceName'] for inst in ec2_stopped_map.values() if inst['InstanceId'] in InstanceIds_stopped}
     filters = [{'Name': 'attachment.instance-id', 'Values': InstanceIds_stopped}]
     attached_volumes = ec2_client.describe_volumes(Filters=filters)
     if attached_volumes['Volumes']:
         attached_volumes = [attachment for volume in attached_volumes['Volumes'] for attachment in volume['Attachments']
-                            if attachment['DeleteOnTermination'] == True and not check_if_given_tag_exists(
-                'KubernetesCluster', volume)]
+                            if attachment['DeleteOnTermination'] == True
+                            and attachment['Device'] != root_devices.get(attachment['InstanceId'])
+                            and not utils.check_if_given_tag_exists('KubernetesCluster', volume.get('Tags', []))]
         print('attached_volumes', attached_volumes)
         for volume in attached_volumes:
             print(f'detaching the volume {volume["VolumeId"]}')
             ec2_client.detach_volume(Device=volume['Device'], InstanceId=volume['InstanceId'], VolumeId=volume['VolumeId'])
         for volume in attached_volumes:
             print(f'deleting the volume {volume["VolumeId"]}')
-            delete_volume(volume['VolumeId'], cluster.region)
+            utils.delete_volume(volume['VolumeId'], cluster.region)
     if len(InstanceIds_running) == 0 and len(InstanceIds_stopped) == 0:
         try:
             print(f'starting node pool sync for {cluster.name}')
@@ -112,25 +46,10 @@ def check_instance_status(cluster:oc_cluster, ec2_running_map:dict, ec2_stopped_
             print(traceback.format_exc())
             print('error while syncing the machine pools for HCP cluster', cluster.name)
 
-    # if len(InstanceIds_running) > 0 and len(InstanceIds_running) > 0:
-    #     filters = [{'Name': 'instance-state-name', 'Values': ['stopped']}]
-    #     current_stopped_instances = ec2_client.describe_instances(InstanceIds=InstanceIds_stopped, Filters=filters)
-    #     current_stopped_instances = [ec2 for ec2 in current_stopped_instances['Reservations']]
-    #     current_stopped_instances = [instance['InstanceId'] for ec2 in current_stopped_instances for instance in
-    #                                  ec2['Instances']]
-    #     if current_stopped_instances:
-    #         print(f'Stopping Running Worker Instances of cluster {cluster.name}', InstanceIds_running)
-    #         ec2_client.stop_instances(InstanceIds=InstanceIds_running)
-    #         print(f'Started hibernating the cluster {cluster.name}')
-def get_ocm_api_token():
-    if not os.path.isfile('ocm_token.txt'):
-        run_command(f'script/./get_ocm_token.sh')
-    ocm_api_token = str(open('ocm_token.txt').read()).strip('\n')
-    print('len(ocm_api_token)', len(ocm_api_token))
-    return ocm_api_token
-def sync_hcp_node_pools(cluster:oc_cluster):
+
+def sync_hcp_node_pools(cluster:utils.OcCluster):
     api_server_base_url =  'https://api.openshift.com/api' if cluster.ocm_account == 'PROD' else 'https://api.stage.openshift.com/api'
-    ocm_api_token = get_ocm_api_token()
+    ocm_api_token = utils.get_ocm_api_token()
     node_pools_response = requests.get(f'{api_server_base_url}/clusters_mgmt/v1/clusters/{cluster.id}/node_pools', headers={'Authorization': f'Bearer {ocm_api_token}'})
     node_pools = node_pools_response.json()
     node_pools = {node_pool['id']:node_pool['replicas'] for node_pool in node_pools['items'] if node_pool['kind'] == 'NodePool'}
@@ -163,24 +82,11 @@ def sync_hcp_node_pools(cluster:oc_cluster):
     return totalNodes
 
 
-
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
 def main():
     ec2_running_instances = {}
-    get_all_instances(ec2_running_instances, 'running')
+    utils.get_all_instances(ec2_running_instances, InstanceState.running)
     ec2_stopped_instances = {}
-    get_all_instances(ec2_stopped_instances, 'stopped')
+    utils.get_all_instances(ec2_stopped_instances, InstanceState.stopped)
 
     clusters = []
     ocm_accounts = ['PROD', 'STAGE']
@@ -202,7 +108,6 @@ def main():
         hibernated_clusters.append(cluster.__dict__)
         print(f'Hibernated {cluster.name}')
     hibernated_json = json.dumps(hibernated_clusters, indent=4)
-    # print(hibernated_json)
 
 
 if __name__ == '__main__':

--- a/src/cloud_cleaner.py
+++ b/src/cloud_cleaner.py
@@ -1,80 +1,45 @@
 import json
+import boto3
 
-import boto3, os
-
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.ocm_account = ocm_account
+import utils
 
 def get_all_cluster_details(ocm_account:str, clusters:list):
-    get_cluster_list(ocm_account)
+    utils.get_cluster_list(ocm_account)
     clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
     for cluster_detail in clusters_details:
-        clusters.append(oc_cluster(cluster_detail, ocm_account))
+        clusters.append(utils.OcCluster(cluster_detail, ocm_account))
     clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
 
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def run_command(command):
-    output = os.popen(command).read()
-    print(output)
-    return output
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    # ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-    #            ec2_map}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
 
 def get_all_ebs_volumes(volumes, current_state):
     client = boto3.client('ec2', region_name='us-east-1')
     regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
     for region in regions:
         volumes[region] = get_ebs_volume_for_region(region, current_state)
-def check_if_given_tag_exists(tag_name, volume):
+
+
+def check_if_given_tag_exists_in_volume(tag_name, volume):
     result = False
     if 'Tags' in volume:
         tags = volume['Tags']
-        print(tags)
         for tag in tags:
             if tag['Key'] == tag_name:
                 result = True
                 break
     return result
+
+
 def get_ebs_volume_for_region(region, current_state):
     ec2_client = boto3.client('ec2', region_name=region)
     filters = [{'Name': 'status', 'Values': [current_state]}]
     volume_map = ec2_client.describe_volumes(Filters=filters, MaxResults=500)
-    volume_map = [volume for volume in volume_map['Volumes'] if not check_if_given_tag_exists(
+    volume_map = [volume for volume in volume_map['Volumes'] if not check_if_given_tag_exists_in_volume(
                 'KubernetesCluster', volume)]
     volume_map = {volume['VolumeId']: volume for volume in
                volume_map}
     print(region, len(volume_map))
     return volume_map
+
 
 def cleanup_available_volumes(volumes:dict):
     for region, ebs_volumes in volumes.items():
@@ -85,11 +50,13 @@ def cleanup_available_volumes(volumes:dict):
             print(f'Deleting volume {volumeId}')
             # ec2_client.delete_volume(VolumeId=volumeId)
 
+
 def get_all_elbs(elbs):
     client = boto3.client('ec2', region_name='us-east-1')
     regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
     for region in regions:
         elbs[region] = get_elbs_for_region(region)
+
 
 def get_elbs_for_region(region):
     aws_client = boto3.client('elb', region_name=region)
@@ -107,6 +74,7 @@ def get_elbs_for_region(region):
 
     return all_elb_map
 
+
 def get_target_groups_health(LoadBalancerArn, region):
     aws_client = boto3.client('elbv2', region_name=region)
     target_groups = aws_client.describe_target_groups(LoadBalancerArn=LoadBalancerArn)
@@ -118,6 +86,7 @@ def get_target_groups_health(LoadBalancerArn, region):
                 healths.append(target['TargetHealth']['State'])
     return healths
 
+
 def name_starts_with_existing_cluster(name, cluster_names:list[str]):
     result = False
     for cluster_name in cluster_names:
@@ -125,6 +94,7 @@ def name_starts_with_existing_cluster(name, cluster_names:list[str]):
             result = True
             break
     return result
+
 
 def elb_belongs_to_existing_cluster( cluster_names:list[str], tags:dict):
     result = False
@@ -174,7 +144,7 @@ def get_all_tags_for_albs(ResourceArns:list, region):
 
     return tags
 
-def cleanup_inactive_elbs(elbs:dict[dict], clusters:dict[oc_cluster]):
+def cleanup_inactive_elbs(elbs:dict[dict], clusters:dict[utils.OcCluster]):
     rosa_clusters_ids = [cluster.id for cluster in clusters if cluster.type == 'rosa']
     osd_cluster_names = [cluster.name for cluster in clusters if cluster.type == 'osd']
     all_cluster_names = [cluster.name for cluster in clusters]
@@ -274,13 +244,6 @@ def cleanup_all_netoworking_data(ec2_running_instances:dict, ec2_stopped_instanc
         all_elastic_ip_addresses  =  ec2_client.describe_addresses()
         all_elastic_ip_addresses = [elastic_ip_address['AllocationId'] for elastic_ip_address in all_elastic_ip_addresses['Addresses']]
         print('elastic_ip_addresses', len(all_elastic_ip_addresses), len(associated_elastic_ip_addresses))
-
-
-
-
-
-
-
 
 
 def main():

--- a/src/cluster_aggregator.py
+++ b/src/cluster_aggregator.py
@@ -1,84 +1,12 @@
 import json
 import time
-
-import boto3
-import os
 import smartsheet
-import re
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.ocm_account = ocm_account
-        self.creation_date = ''
-        self.creator_name = ''
-        self.creator_email = ''
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_all_cluster_details(ocm_account:str, clusters:list):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-    update_cluster_details(clusters)
+import utils
+from utils import InstanceState
 
 
-def update_cluster_details(clusters:list[oc_cluster]):
-    for cluster in clusters:
-        run_command(f'script/./get_cluster_details.sh {cluster.ocm_account} {cluster.id}')
-        details = json.load(open(f'{cluster.id}_details.json'))
-        cluster.creation_date = details['creation_date']
-        cluster.creator_name = details['creator_name']
-        if details['creator_email'] and details['creator_email'] != 'null':
-            cluster.creator_email = details['creator_email']
-            if '+' in cluster.creator_email:
-                cluster.creator_email = get_original_email_address(cluster.creator_email)
-
-
-def get_original_email_address(email:str):
-    parts = email.split('@')
-    original_prefix = parts[0].split('+')[0]
-    return f'{original_prefix}@{parts[1]}'
-
-
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def run_command(command):
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-def build_cells(cluster: oc_cluster, column_map:dict):
+def build_cells(cluster: utils.OcCluster, column_map:dict):
     cells = []
 
     column_object = {}
@@ -136,7 +64,7 @@ def build_cells(cluster: oc_cluster, column_map:dict):
 
     return cells
 
-def update_smartsheet_data(clusters:dict[oc_cluster]):
+def update_smartsheet_data(clusters:dict[utils.OcCluster], allow_deletion=True):
     column_map = {}
     smart = smartsheet.Smartsheet()
     # response = smart.Sheets.list_sheets()
@@ -144,7 +72,6 @@ def update_smartsheet_data(clusters:dict[oc_cluster]):
     sheet = smart.Sheets.get_sheet(sheed_id)
     for column in sheet.columns:
         column_map[column.title] = column.id
-    print(column_map)
 
     # process existing data
     existingRows = {row.cells[0].value: row.id for row in sheet.rows}
@@ -171,13 +98,13 @@ def update_smartsheet_data(clusters:dict[oc_cluster]):
 
     if smartsheet_existing_data:
         payload = json.dumps(smartsheet_existing_data, indent=4)
-        print('Updating existing clusters', payload)
+        print('Updating existing clusters')
         response = smart.Passthrough.put(f'/sheets/{sheed_id}/rows', payload)
         # print(response)
 
     if smartsheet_new_data:
         payload = json.dumps(smartsheet_new_data, indent=4)
-        print('Adding new clusters', payload)
+        print('Adding new clusters...')
         response = smart.Passthrough.post(f'/sheets/{sheed_id}/rows', payload)
         # print(response)
         payload = json.dumps({'sortCriteria': [{'columnId': column_map['Name'], 'direction': 'ASCENDING'}]})
@@ -195,12 +122,12 @@ def update_smartsheet_data(clusters:dict[oc_cluster]):
                     send_request_to_update_inactive_hours(row, column_map, smart)
 
 
-    if smartsheet_deleted_data:
-        print('Deleting old clusters', smartsheet_deleted_data)
+    if smartsheet_deleted_data and allow_deletion:
+        print('Deleting old clusters...')
         delete_url = f'/sheets/{sheed_id}/rows?ids={",".join(smartsheet_deleted_data)}'
-        print(delete_url)
         response = smart.Passthrough.delete(delete_url)
         # print(response)
+
 
 def send_request_to_update_inactive_hours(row:smartsheet.smartsheet.models.row, column_map:dict, smart:smartsheet.smartsheet.Smartsheet):
     sheed_id = 7086931905040260
@@ -214,54 +141,33 @@ def send_request_to_update_inactive_hours(row:smartsheet.smartsheet.models.row, 
     # print(response)
 
 
-
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags'] if 'Tags' in instance else []))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags'] if 'Tags' in instance else []))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def update_rosa_hosted_clusters_status(clusters:list[oc_cluster]):
+def update_rosa_hosted_clusters_status(clusters:list[utils.OcCluster]):
     ec2_instances = {}
-    get_all_instances(ec2_instances, 'running')
+    utils.get_all_instances(ec2_instances, InstanceState.running)
     for cluster in clusters:
         if cluster.type == 'rosa' and cluster.hcp == 'true':
-            worker_instances = [instance_name for instance_name in ec2_instances[cluster.region] if worker_node_belongs_to_the_hcp_cluster(ec2_instances[cluster.region][instance_name], cluster.name)]
+            worker_instances = [instance_name for instance_name in ec2_instances[cluster.region] if utils.worker_node_belongs_to_the_hcp_cluster(ec2_instances[cluster.region][instance_name], cluster.name)]
             if len(worker_instances) == 0:
                 cluster.status = 'hibernating'
 
-def main():
-    clusters = []
+
+def main(cluster_list=None, needs_data_refresh=True, allow_smartsheet_deletion=True):
+    if cluster_list is None:
+        clusters = []
+    else:
+        clusters = cluster_list
     ocm_accounts = ['PROD', 'STAGE']
 
-    for ocm_account in ocm_accounts:
-        get_all_cluster_details(ocm_account, clusters)
-    update_rosa_hosted_clusters_status(clusters)
+    if needs_data_refresh:
+        for ocm_account in ocm_accounts:
+            utils.get_all_cluster_details(ocm_account, clusters)
+        update_rosa_hosted_clusters_status(clusters)
+    else:
+        utils.update_cluster_details(clusters)
 
     names = [cluster.name for cluster in clusters]
     # print(names)
-    update_smartsheet_data(clusters)
+    update_smartsheet_data(clusters, allow_deletion=allow_smartsheet_deletion)
 
 
 

--- a/src/hibernate_cluster.py
+++ b/src/hibernate_cluster.py
@@ -1,213 +1,158 @@
-import json
 import sys
 import time
 import boto3
-import os
 import argparse
 import cluster_aggregator as ca
-import smartsheet
-import re
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
+import utils
+from utils import InstanceState
 
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-def get_all_cluster_details(ocm_account:str, clusters:dict):
-    get_cluster_list(ocm_account)
+
+def get_all_cluster_details(ocm_account:str):
+    utils.get_cluster_list(ocm_account)
+    clusters = []
     clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
     for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
+        cluster = utils.OcCluster(cluster_detail, ocm_account)
         if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
+            utils.get_ipi_cluster_name(cluster)
         if cluster.cloud_provider == 'aws' and (
                 cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
             clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws' and (cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name))]
+    return clusters
 
 
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
+# === CLUSTER HIBERNATION FUNCTIONS ==== ===========================================================
+def hibernate_generic_cluster(cluster):
+    print(f"=== Getting all EC2 instances for region {cluster.region} and cluster {cluster.name} ===",
+          flush=True)
+    ec2_map = utils.get_instances(
+        cluster=cluster,
+        current_state=[InstanceState.running, InstanceState.pending],
+    )
 
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
+    print(f"=== Hibernating {cluster.name} ===", flush=True)
+    if cluster.hcp == "false":
+        if cluster.type == 'ocp':
+            hibernate_ipi_cluster(cluster, ec2_map)
+        else:
+            if cluster.status == "ready":
+                hibernate_cluster(cluster)
+            else:
+                print(
+                    f'Cluster {cluster.name} is not in ready state, please wait for it to be ready and try again',
+                    flush=True
+                )
+    else:
+        hibernate_hypershift_cluster(cluster, ec2_map)
 
 
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
+def hibernate_cluster(cluster):
+    utils.run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
 
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
+
+def hibernate_ipi_cluster(cluster, ec2_map:dict):
     result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
 
-def check_if_given_tag_exists(tag_name, tags:list[dict]):
-    print(tags)
-    result = False
-    for tag in tags:
-        if tag['Key'] == tag_name:
-            result = True
-            break
-    return result
-
-def delete_volume(volume_id, region):
-    ec2_client = boto3.client('ec2', region_name=region)
-    for attempt in range(7):
-        try:
-            ec2_client.delete_volume(VolumeId=volume_id)
-            print(f'Deleted the volume {volume_id}')
-        except:
-            time.sleep(5)
-
-
-
-def hibernate_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-
-    result = False
+    # The startswith pre-filter may miss IPI nodes — it caused a bug in HCP clusters.
+    # If IPI nodes aren't being correctly hibernated, investigate this filter first.
     worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
     ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
+    InstanceIds = [
+        ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes
+        if utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
     if len(InstanceIds) > 0:
         print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
         ec2_client.stop_instances(InstanceIds=InstanceIds)
-        wait_for_ipi_cluster_to_be_hibernated(cluster, worker_count)
         print(f'Started hibernating the cluster {cluster.name}')
         result = True
     else:
         print(f'Cluster {cluster.name} is already hibernated.')
     return result
 
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
 
-def hybernate_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
+def hibernate_hypershift_cluster(cluster:utils.OcCluster, ec2_map:dict, wait_for_stop=True, cleanup_volumes=True):
     ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
+    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in ec2_map if
+                   utils.worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
+
     if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
+        print(f'Stopping running worker instances of cluster {cluster.name}: {InstanceIds}', flush=True)
         worker_count = len(InstanceIds)
         ec2_client.stop_instances(InstanceIds=InstanceIds)
-        wait_for_rosa_cluster_to_be_hibernated(cluster, worker_count)
-        # detach and delete the volumes
-        filters = [{'Name': 'attachment.instance-id', 'Values': InstanceIds}]
-        attached_volumes = ec2_client.describe_volumes(Filters=filters)
-        attached_volumes = [attachment for volume in attached_volumes['Volumes'] for attachment in volume['Attachments']
-                            if attachment['DeleteOnTermination'] == True and not check_if_given_tag_exists(
-                'KubernetesCluster', volume['Tags'])]
-        print('attached_volumes', attached_volumes)
-        for volume in attached_volumes:
-            print(f'detaching the volume {volume["VolumeId"]}')
-            ec2_client.detach_volume(Device=volume['Device'], InstanceId=volume['InstanceId'], VolumeId=volume['VolumeId'])
-        for volume in attached_volumes:
-            print(f'deleting the volume {volume["VolumeId"]}')
-            delete_volume(volume['VolumeId'], cluster.region)
-        print(f'Done hibernating the cluster {cluster.name}')
+        if wait_for_stop:
+            wait_for_rosa_cluster_to_be_hibernated(cluster, worker_count)
+        if cleanup_volumes:
+            root_devices = {inst['InstanceId']: inst['RootDeviceName'] for inst in ec2_map.values() if inst['InstanceId'] in InstanceIds}
+            filters = [{'Name': 'attachment.instance-id', 'Values': InstanceIds}]
+            attached_volumes = ec2_client.describe_volumes(Filters=filters)
+            attached_volumes = [attachment for volume in attached_volumes['Volumes'] for attachment in volume['Attachments']
+                                if attachment['DeleteOnTermination'] == True
+                                and attachment['Device'] != root_devices.get(attachment['InstanceId'])
+                                and not utils.check_if_given_tag_exists('KubernetesCluster', volume.get('Tags', []))]
+            print('attached_volumes', attached_volumes, flush=True)
+            for volume in attached_volumes:
+                print(f'detaching the volume {volume["VolumeId"]}', flush=True)
+                ec2_client.detach_volume(Device=volume['Device'], InstanceId=volume['InstanceId'], VolumeId=volume['VolumeId'])
+            for volume in attached_volumes:
+                print(f'deleting the volume {volume["VolumeId"]}', flush=True)
+                utils.delete_volume(volume['VolumeId'], cluster.region)
+        print(f'Done hibernating the cluster {cluster.name}', flush=True)
     else:
-        print(f'Cluster {cluster.name} is already hibernated.')
+        print(f'Cluster {cluster.name} is already hibernated.', flush=True)
 
 
-def wait_for_rosa_cluster_to_be_hibernated(cluster:oc_cluster, worker_count:int):
+def wait_for_rosa_cluster_to_be_hibernated(cluster:utils.OcCluster, worker_count:int):
     time.sleep(15)
-    ec2_map = get_instances_for_region(cluster.region, 'stopped')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-    while len(InstanceIds) < worker_count:
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'stopped')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
+    ec2_map = utils.get_instances(cluster=cluster)
+    states = utils.group_ec2_instances_by_state(ec2_map)
 
-    status_map = get_instance_status(cluster, InstanceIds)
-    while set(status_map.values()) != set(['stopped']):
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
+    print(f"Waiting for {worker_count} worker nodes to stop, please wait...", flush=True)
+    while len(states[InstanceState.stopped]) < worker_count:
+        print(f"\t{len(states[InstanceState.stopped])}/{worker_count} nodes are stopped.", flush=True)
+        utils.print_ec2_instance_state(ec2_map, prefix="\t\t", filtered_states=[InstanceState.terminated])
 
-def wait_for_ipi_cluster_to_be_hibernated(cluster:oc_cluster, worker_count:int):
+        time.sleep(5)
+        ec2_map = utils.get_instances(cluster=cluster)
+        states = utils.group_ec2_instances_by_state(ec2_map)
+
+    print("All nodes stopped", flush=True)
+
+
+
+    state_map = utils.get_instance_state_by_id(cluster, states[InstanceState.stopped])
+    while set(state_map.values()) != set([InstanceState.stopped]):
+        print('\tWaiting for worker nodes to report status=stopped, will check again in 5s...', flush=True)
+        time.sleep(5)
+        state_map = utils.get_instance_state_by_id(cluster, states[InstanceState.stopped])
+
+
+def wait_for_ipi_cluster_to_be_hibernated(cluster:utils.OcCluster, worker_count:int):
     time.sleep(15)
-    ec2_map = get_instances_for_region(cluster.region, 'stopped')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-') and worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+    ec2_map = utils.get_instances(cluster=cluster, current_state=InstanceState.stopped)
+    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map
+                   if ec2_name.startswith(f'{cluster.internal_name}-')
+                   and utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+
+    print(f"=== Waiting for {len(InstanceIds)} worker nodes to stop ===", flush=True)
     while len(InstanceIds) < worker_count:
-        print('Worker nodes stopping, please wait...')
+        print(f'\t{len(InstanceIds)}/{worker_count} nodes are stopped:', flush=True)
         time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'stopped')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-') and worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+        ec2_map = utils.get_instances(cluster=cluster, current_state=InstanceState.stopped)
+        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map
+                       if ec2_name.startswith(f'{cluster.internal_name}-')
+                       and utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
 
-    status_map = get_instance_status(cluster, InstanceIds)
-    while set(status_map.values()) != set(['stopped']):
-        print('Worker nodes stopping, please wait...')
+    print("\tAll nodes stopped", flush=True)
+
+    state_map = utils.get_instance_state_by_id(cluster, InstanceIds)
+    while set(state_map.values()) != set([InstanceState.stopped]):
+        print('\tWaiting for worker nodes to report status=stopped, will check again in 5s...', flush=True)
         time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
+        state_map = utils.get_instance_state_by_id(cluster, InstanceIds)
 
 
-def get_instance_status(cluster:oc_cluster, InstanceIds:list):
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    ec2_map = ec2_client.describe_instances(InstanceIds=InstanceIds)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    status_map = {ec2['InstanceId']:ec2['State']['Name'] for ec2 in ec2_map}
-    return status_map
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
-
+# === MAIN FUNCTION ================================================================================
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Hibernate the given cluster"
@@ -224,24 +169,16 @@ def parse_arguments():
 
     return args
 
-def sanitize_cluster_name(cluster_name:str):
-    if cluster_name.count('-') == 4:
-        cluster_name = cluster_name[:28]
-    return cluster_name
+
 def main():
     args = parse_arguments()
     args.ocm_account = args.ocm_account.split(' ')[0]
 
-
-
-    clusters = []
-
-    get_all_cluster_details(args.ocm_account, clusters)
-
-
+    print("=== Getting details for all clusters ===", flush=True)
+    clusters = get_all_cluster_details(args.ocm_account)
 
     available_clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-    target_cluster = [cluster for cluster in available_clusters if cluster.name == sanitize_cluster_name(args.cluster_name)]
+    target_cluster = [cluster for cluster in available_clusters if cluster.name == utils.sanitize_cluster_name(args.cluster_name)]
     if len(target_cluster) > 1:
         sys.exit("More than one clusters found with give name.")
 
@@ -250,24 +187,12 @@ def main():
 
     if len(target_cluster) == 1:
         target_cluster = target_cluster[0]
-        ec2_map = get_instances_for_region(target_cluster.region, 'running')
-        print('starting to hibernate ', target_cluster.name)
-        if target_cluster.hcp == "false":
-            if target_cluster.type == 'ocp':
-                hibernate_ipi_cluster(target_cluster, ec2_map)
-            else:
-                if target_cluster.status == "ready":
-                    hibernate_cluster(target_cluster)
-                else:
-                    print(
-                        f'Cluster {target_cluster.name} is not in ready state, please wait for it to be ready and try again')
-        else:
-            hybernate_hypershift_cluster(target_cluster, ec2_map)
-        print('starting the smartsheet update')
-        ca.main()
-        print(f'Hibernated the cluster:{target_cluster.name}')
-        # print(target_cluster.__dict__)
+        hibernate_generic_cluster(target_cluster)
 
+        print("=== Updating cluster status in Smartsheet ===")
+        ca.main(cluster_list=[target_cluster], needs_data_refresh=False, allow_smartsheet_deletion=False)
+
+        print(f'Hibernated cluster: {target_cluster.name}')
 
 
 if __name__ == '__main__':

--- a/src/hibernate_clusters_daily.py
+++ b/src/hibernate_clusters_daily.py
@@ -1,217 +1,18 @@
-import json
-import boto3
-import time, datetime
-import os
-import smartsheet
-import re
+import utils
+from hibernate_cluster import (
+    hibernate_generic_cluster,
+    get_all_cluster_details
+)
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
-        self.inactive_hours_start = None
-        self.inactive_hours_end = None
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def check_if_given_tag_exists(tag_name, tags:list[dict]):
-    print(tags)
-    result = False
-    for tag in tags:
-        if tag['Key'] == tag_name:
-            result = True
-            break
-    return result
-
-def delete_volume(volume_id, region):
-    ec2_client = boto3.client('ec2', region_name=region)
-    for attempt in range(7):
-        try:
-            ec2_client.delete_volume(VolumeId=volume_id)
-            print(f'Deleted the volume {volume_id}')
-        except:
-            time.sleep(5)
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_all_cluster_details(ocm_account:str, clusters:dict):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-
-def hybernate_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-
-        print(f'Started hibernating the cluster {cluster.name}')
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-
-def get_instance_status(cluster:oc_cluster, InstanceIds:list):
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    ec2_map = ec2_client.describe_instances(InstanceIds=InstanceIds)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    status_map = {ec2['InstanceId']:ec2['State']['Name'] for ec2 in ec2_map}
-    return status_map
-
-def wait_for_rosa_cluster_to_be_hibernated(cluster:oc_cluster, worker_count:int):
-    time.sleep(5)
-    ec2_map = get_instances_for_region(cluster.region, 'stopped')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-    while len(InstanceIds) < worker_count:
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'stopped')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-
-    status_map = get_instance_status(cluster, InstanceIds)
-    while set(status_map.values()) != set(['stopped']):
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
-
-def get_clusters_from_smartsheet():
-    column_map = {}
-    smart = smartsheet.Smartsheet()
-    # response = smart.Sheets.list_sheets()
-    sheed_id = 7086931905040260
-    inactive_hours_start_index, inactive_hours_end_index = 5, 6
-    sheet = smart.Sheets.get_sheet(sheed_id)
-
-    # get existing data
-    smartsheet_data = {row.cells[0].value: [row.cells[inactive_hours_start_index].value, row.cells[inactive_hours_start_index].value] for row in sheet.rows}
-    return smartsheet_data
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def good_time_to_hibernate_cluster(inactive_hours_start:str):
-    buffer_hours = 2
-    buffer_seconds = buffer_hours * 60 * 60
-    day_start_time = '00:00:00'
-    day_end_time = '23:59:59'
-    try:
-        inactive_hours_start = datetime.datetime.strptime(inactive_hours_start, '%H:%M:%S')
-    # if the inactive hours start is misconfigured, default to hibernating cluster immediately
-    except ValueError:
-        return False
-
-    current_utc_time = datetime.datetime.strptime(datetime.datetime.now(datetime.timezone.utc).strftime('%H:%M:%S'),                                                      '%H:%M:%S')
-    day_start_time = datetime.datetime.strptime(day_start_time, '%H:%M:%S')
-    day_end_time = datetime.datetime.strptime(day_end_time, '%H:%M:%S')
-    diff = (current_utc_time - inactive_hours_start).total_seconds()
-    if diff < 0 and 24 - buffer_hours < inactive_hours_start.hour <= 24 and 0 <= current_utc_time.hour <= buffer_hours:
-        diff = (day_end_time - inactive_hours_start).total_seconds() + (
-                current_utc_time - day_start_time).total_seconds()
-
-    return 0 <= diff <= buffer_seconds
-
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
-def hibernate_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-
-    result = False
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-        print(f'Started hibernating the cluster {cluster.name}')
-        result = True
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-    return result
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
 def main():
-    ec2_instances = {}
-    get_all_instances(ec2_instances, 'running')
-
-    clusters:list[oc_cluster] = []
+    print("=== Getting details for all clusters ===", flush=True)
+    clusters:list[utils.OcCluster] = []
     ocm_accounts = ['PROD', 'STAGE']
-
     for ocm_account in ocm_accounts:
-        get_all_cluster_details(ocm_account, clusters)
+        clusters += get_all_cluster_details(ocm_account)
 
-    smartsheet_data = get_clusters_from_smartsheet()
+    print("=== Getting all clusters from Smartsheet ===", flush=True)
+    smartsheet_data = utils.get_clusters_from_smartsheet()
 
     # updating inactive_hours_start for each cluster based on smartsheet
     for cluster in clusters:
@@ -219,44 +20,31 @@ def main():
             print(f'{cluster.name} ({cluster.id}) not found in smartsheet data')
             continue
         
-        smartsheet_cluster_info = smartsheet_data[cluster.id]
+        cluster_inactive_hours_start = smartsheet_data[cluster.id][utils.ClusterSmartsheetColumns.INACTIVE_HOURS_START]
        
-        if not smartsheet_cluster_info[0]:
+        if not cluster_inactive_hours_start:
             print(f'Start time not found for {cluster.name}')
             continue
-        if smartsheet_cluster_info[0].count(':') < 1:
-            print(f'Invalid inactive_hours_start {smartsheet_cluster_info[0]} for cluster {cluster.name}')
+        if cluster_inactive_hours_start.count(':') < 1:
+            print(f'Invalid inactive_hours_start {cluster_inactive_hours_start} for cluster {cluster.name}')
             continue
         
         # checking to see if smartsheet time entry is missing the seconds part
-        if smartsheet_cluster_info[0].count(':') == 1:
-            smartsheet_cluster_info[0] += ':00'
-        cluster.inactive_hours_start = smartsheet_cluster_info[0]
+        if cluster_inactive_hours_start.count(':') == 1:
+            cluster_inactive_hours_start += ':00'
+        cluster.inactive_hours_start = cluster_inactive_hours_start
 
     hibernated_clusters = []
     no_action_clusters = []
 
+    print("=== Hibernating clusters ===", flush=True)
     for cluster in clusters:
-    
-        if cluster.inactive_hours_start and good_time_to_hibernate_cluster(cluster.inactive_hours_start):
-            if cluster.hcp == "false":
-                if cluster.type == 'ocp':
-                    print("Hibernating IPI Cluster - ", cluster.name)
-                    hibernate_ipi_cluster(cluster, ec2_instances[cluster.region])
-                else:
-                    print("Hibernating OSD or ROSA Classic Cluster - ", cluster.name)
-                    hibernate_cluster(cluster)
-            else:
-                hybernate_hypershift_cluster(cluster, ec2_instances[cluster.region])
-                print("Hibernating Hypershift Cluster - ", cluster.name)
+        # default to hibernating the cluster immediately if inactive_hours are set incorrectly
+        if cluster.inactive_hours_start and utils.within_two_hour_window_after(cluster.inactive_hours_start, default_decision=True):
+            hibernate_generic_cluster(cluster)
             hibernated_clusters.append(cluster.__dict__)
         else:
             no_action_clusters.append(cluster.__dict__)
-
-    # print(json.dumps(hibernated_clusters, indent=4))
-
-    print("No action taken for the following cluster:")
-    # print(json.dumps(no_action_clusters, indent=4))
 
 if __name__ == '__main__':
     main()

--- a/src/hibernate_clusters_weekend.py
+++ b/src/hibernate_clusters_weekend.py
@@ -1,195 +1,37 @@
 import json
-import time
 
 import boto3
-import os
+from hibernate_cluster import (
+    hibernate_generic_cluster,
+    get_all_cluster_details
+)
 
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
-def get_all_cluster_details(ocm_account:str, clusters:dict):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
-
-def check_if_given_tag_exists(tag_name, tags:list[dict]):
-    print(tags)
-    result = False
-    for tag in tags:
-        if tag['Key'] == tag_name:
-            result = True
-            break
-    return result
-
-def delete_volume(volume_id, region):
-    ec2_client = boto3.client('ec2', region_name=region)
-    for attempt in range(7):
-        try:
-            ec2_client.delete_volume(VolumeId=volume_id)
-            print(f'Deleted the volume {volume_id}')
-        except:
-            time.sleep(5)
-def hybernate_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-    result = False
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-
-        print(f'Started hibernating the cluster {cluster.name}')
-        result = True
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-    return result
-
-def hibernate_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-
-    result = False
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-        print(f'Started hibernating the cluster {cluster.name}')
-        result = True
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-    return result
-
-
-def get_instance_status(cluster:oc_cluster, InstanceIds:list):
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    ec2_map = ec2_client.describe_instances(InstanceIds=InstanceIds)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    status_map = {ec2['InstanceId']:ec2['State']['Name'] for ec2 in ec2_map}
-    return status_map
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
 def main():
-    ec2_instances = {}
-    get_all_instances(ec2_instances, 'running')
-
+    print("=== Getting details for all clusters ===", flush=True)
     clusters = []
     ocm_accounts = ['PROD', 'STAGE']
-
     for ocm_account in ocm_accounts:
-        get_all_cluster_details(ocm_account, clusters)
+        clusters += get_all_cluster_details(ocm_account)
 
+    print("=== Identifying clusters to hibernate ===", flush=True)
     clusters_to_hibernate = [cluster for cluster in clusters if cluster.cloud_provider == 'aws' and cluster.status == 'ready']
-    print('cluster to hibernate')
     for cluster in clusters_to_hibernate:
         print(cluster.name, cluster.type)
     DO_NOT_HIBERNATE_LIST = ['vteam-uat', 'vteam-stage']
 
+    print("=== Hibernating clusters ===", flush=True)
     hibernated_clusters = []
     for cluster in clusters_to_hibernate:
         print('starting with', cluster.name, cluster.type)
-        outcome = True
         if cluster.name in DO_NOT_HIBERNATE_LIST:
             print(f'skipping the cluster {cluster.name}')
             continue
-        elif cluster.hcp == "false":
-            if cluster.type == 'ocp':
-                hibernate_ipi_cluster(cluster, ec2_instances[cluster.region])
-                print('hibernating IPI cluster - ', cluster.name)
-            else:
-                hibernate_cluster(cluster)
-                print("OSD or ROSA Classic - ", cluster.name)
         else:
-            outcome = hybernate_hypershift_cluster(cluster, ec2_instances[cluster.region])
-            print("Hypershift cluster - ", cluster.name)
-        if outcome:
-            hibernated_clusters.append(cluster.__dict__)
+            hibernate_generic_cluster(cluster)
+        hibernated_clusters.append(cluster.__dict__)
         print(f'Hibernated {cluster.name}')
+
     hibernated_json = json.dumps(hibernated_clusters, indent=4)
     # print(hibernated_json)
     open('hibernated_latest.json', 'w').write(hibernated_json)

--- a/src/hibernate_untracked_clusters_during_shutdown.py
+++ b/src/hibernate_untracked_clusters_during_shutdown.py
@@ -1,222 +1,43 @@
-import json
-import boto3
-import time, datetime
-import os
-import smartsheet
-import re
+import utils
+from utils import InstanceState
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
-        self.inactive_hours_start = None
-        self.inactive_hours_end = None
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def check_if_given_tag_exists(tag_name, tags:list[dict]):
-    print(tags)
-    result = False
-    for tag in tags:
-        if tag['Key'] == tag_name:
-            result = True
-            break
-    return result
-
-def delete_volume(volume_id, region):
-    ec2_client = boto3.client('ec2', region_name=region)
-    for attempt in range(7):
-        try:
-            ec2_client.delete_volume(VolumeId=volume_id)
-            print(f'Deleted the volume {volume_id}')
-        except:
-            time.sleep(5)
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_all_cluster_details(ocm_account:str, clusters:dict):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
+from hibernate_cluster import (
+    hibernate_cluster,
+    hibernate_hypershift_cluster,
+    hibernate_ipi_cluster,
+    get_all_cluster_details
+)
 
 
-def hybernate_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-
-        print(f'Started hibernating the cluster {cluster.name}')
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-
-def get_instance_status(cluster:oc_cluster, InstanceIds:list):
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    ec2_map = ec2_client.describe_instances(InstanceIds=InstanceIds)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    status_map = {ec2['InstanceId']:ec2['State']['Name'] for ec2 in ec2_map}
-    return status_map
-
-def wait_for_rosa_cluster_to_be_hibernated(cluster:oc_cluster, worker_count:int):
-    time.sleep(5)
-    ec2_map = get_instances_for_region(cluster.region, 'stopped')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-    while len(InstanceIds) < worker_count:
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'stopped')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-
-    status_map = get_instance_status(cluster, InstanceIds)
-    while set(status_map.values()) != set(['stopped']):
-        print('Worker nodes stopping, please wait...')
-        time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
-
-def get_clusters_from_smartsheet():
-    column_map = {}
-    smart = smartsheet.Smartsheet()
-    # response = smart.Sheets.list_sheets()
-    sheed_id = 7086931905040260
-    inactive_hours_start_index, current_status_indedx = 5, 2
-    sheet = smart.Sheets.get_sheet(sheed_id)
-
-    # get existing data
-    smartsheet_data = {row.cells[0].value: [row.cells[inactive_hours_start_index].value, row.cells[current_status_indedx].value] for row in sheet.rows}
-    return smartsheet_data
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def good_time_to_hibernate_cluster(inactive_hours_start:str):
-    buffer_hours = 2
-    buffer_seconds = buffer_hours * 60 * 60
-    day_start_time = '00:00:00'
-    day_end_time = '23:59:59'
-    inactive_hours_start = datetime.datetime.strptime(inactive_hours_start, '%H:%M:%S')
-    current_utc_time = datetime.datetime.strptime(datetime.datetime.now(datetime.timezone.utc).strftime('%H:%M:%S'),
-                                         '%H:%M:%S')
-    day_start_time = datetime.datetime.strptime(day_start_time, '%H:%M:%S')
-    day_end_time = datetime.datetime.strptime(day_end_time, '%H:%M:%S')
-    diff = (current_utc_time - inactive_hours_start).total_seconds()
-    if diff < 0 and 24 - buffer_hours < inactive_hours_start.hour <= 24 and  0 <= current_utc_time.hour <= buffer_hours:
-        diff = (day_end_time - inactive_hours_start).total_seconds() + (current_utc_time - day_start_time).total_seconds()
-
-    return 0 <= diff <= buffer_seconds
-
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
-def hibernate_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-
-    result = False
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
-    if len(InstanceIds) > 0:
-        print(f'Stopping Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.stop_instances(InstanceIds=InstanceIds)
-        print(f'Started hibernating the cluster {cluster.name}')
-        result = True
-    else:
-        print(f'Cluster {cluster.name} is already hibernated.')
-    return result
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
 def main():
     ec2_instances = {}
-    get_all_instances(ec2_instances, 'running')
 
-    clusters:list[oc_cluster] = []
+    print("=== Getting all running EC2 instances ===", flush=True)
+    utils.get_all_instances(ec2_instances, [InstanceState.running, InstanceState.pending])
+
+    clusters:list[utils.OcCluster] = []
     ocm_accounts = ['PROD', 'STAGE']
 
+    print("=== Getting details for all clusters ===", flush=True)
     for ocm_account in ocm_accounts:
         get_all_cluster_details(ocm_account, clusters)
 
+    print("=== Identifying clusters to hibernate ===", flush=True)
     clusters_to_hibernate = [cluster for cluster in clusters if cluster.cloud_provider == 'aws' and cluster.status == 'ready']
-    print('cluster to hibernate')
     for cluster in clusters_to_hibernate:
         print(cluster.name, cluster.type)
     DO_NOT_HIBERNATE_LIST = ['vteam-uat', 'vteam-stage']
 
 
-    smartsheet_data = get_clusters_from_smartsheet()
+    print("=== Getting all clusters from Smartsheet ===", flush=True)
+    smartsheet_data = utils.get_clusters_from_smartsheet()
+
+    print("=== Hibernating clusters ===", flush=True)
     hibernated_clusters = []
     for cluster in clusters_to_hibernate:
-        if cluster.id in smartsheet_data and not smartsheet_data[cluster.id][0] and smartsheet_data[cluster.id][1] == 'ready':
+        if (cluster.id in smartsheet_data
+                and not smartsheet_data[cluster.id][utils.ClusterSmartsheetColumns.INACTIVE_HOURS_START]
+                and smartsheet_data[cluster.id][utils.ClusterSmartsheetColumns.STATUS] == 'ready'):
             print('starting with', cluster.name, cluster.type)
             if cluster.name in DO_NOT_HIBERNATE_LIST:
                 print(f'skipping the cluster {cluster.name}')
@@ -229,12 +50,9 @@ def main():
                     hibernate_cluster(cluster)
                     print("OSD or ROSA Classic - ", cluster.name)
             else:
-                hybernate_hypershift_cluster(cluster, ec2_instances[cluster.region])
+                hibernate_hypershift_cluster(cluster, ec2_instances[cluster.region], wait_for_stop=False, cleanup_volumes=False)
                 print("Hypershift cluster - ", cluster.name)
             hibernated_clusters.append(cluster.__dict__)
-
-
-    # print(json.dumps(hibernated_clusters, indent=4))
 
 
 if __name__ == '__main__':

--- a/src/main.py
+++ b/src/main.py
@@ -2,36 +2,21 @@ import json
 import boto3
 import os
 
+import utils
 
-class oc_cluster:
-    def __init__(self, cluster_detail):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
+
 def get_cluster_list():
-    run_command('ocm list clusters > clusters.txt')
-def run_command(command):
-    output = os.popen(command).read()
-    print(output)
-    return output
+    utils.run_command('ocm list clusters > clusters.txt')
+
 
 def hibernate_cluster(cluster_name):
     commmand = f'ocm hibernate cluster {cluster_name}'
-    run_command(commmand)
+    utils.run_command(commmand)
     print(f'Hibernated {cluster_name}')
 
 def resume_cluster(cluster_name):
     commmand = f'ocm hibernate cluster {cluster_name}'
-    run_command(commmand)
+    utils.run_command(commmand)
     print(f'Hibernated {cluster_name}')
 def main():
 
@@ -46,7 +31,7 @@ def main():
     get_cluster_list()
     clusters_details = open('clusters.txt').readlines()
     for cluster_detail in clusters_details:
-        clusters.append(oc_cluster(cluster_detail))
+        clusters.append(utils.OcCluster(cluster_detail))
     clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
     print(len(clusters))
     cluster_names = [cluster.name for cluster in clusters]

--- a/src/people_populator.py
+++ b/src/people_populator.py
@@ -22,12 +22,8 @@ def parse_people_details():
 
 
 def get_people_details(org:str):
-    run_command(f'../script/./get_people_details.sh {org}')
+    utils.run_command(f'../script/./get_people_details.sh {org}')
 
-def run_command(command):
-    output = os.popen(command).read()
-    print(output)
-    return output
 
 def build_cells(employee: employee, column_map:dict):
     cells = []

--- a/src/resume_cluster.py
+++ b/src/resume_cluster.py
@@ -1,226 +1,441 @@
 import json
 import sys
 import time
+from typing import Callable
+
 import boto3
-import os
 import argparse
+
+import botocore
+import requests
 import cluster_aggregator as ca
-import smartsheet, requests
-import re
-import traceback
 
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
+import utils
+from utils import InstanceState
+from hibernate_cluster import get_all_cluster_details
 
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
 
-def get_all_cluster_details(ocm_account:str, clusters:list):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
+# === CLUSTER RESUME FUNCTIONS =====================================================================
+def resume_generic_cluster(cluster):
+    print(f"=== Getting all EC2 instances for region {cluster.region} and cluster {cluster.name} ===",
+          flush=True)
+    ec2_stopped_map, ec2_running_map = utils.get_stopped_and_running_ec2_maps_for_cluster(cluster)
+
+    print(f"=== Resuming {cluster.name} ===", flush=True)
+    if cluster.hcp == "false":
         if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws' and (cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name))]
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags'] if 'Tags' in instance else []))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags'] if 'Tags' in instance else []))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def resume_hypershift_cluster(cluster:oc_cluster, ec2_map:dict, ec2_running_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    worker_nodes_running = [ec2_name for ec2_name in ec2_running_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    InstanceIds_Running = [ec2_running_map[worker_node]['InstanceId'] for worker_node in worker_nodes_running if worker_node_belongs_to_the_hcp_cluster(ec2_running_map[worker_node], cluster.name)]
-
-    if len(InstanceIds) == 0 and len(InstanceIds_Running) ==0:
-        worker_count = sync_hcp_node_pools(cluster)
-        wait_for_rosa_cluster_to_be_ready(cluster, worker_count)
-    elif len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.terminate_instances(InstanceIds=InstanceIds)
-        wait_for_rosa_cluster_to_be_ready(cluster, worker_count)
-        print(f'Done resuming the cluster {cluster.name}')
+            resume_ipi_cluster(cluster, ec2_stopped_map)
+        else:
+            if cluster.status == "hibernating":
+                resume_cluster(cluster)
+            else:
+                print(f'Cluster {cluster.name} is not in hibernating state')
     else:
-        print(f'Cluster {cluster.name} is already running.')
+        resume_hypershift_cluster(cluster, ec2_stopped_map, ec2_running_map)
 
 
-def get_ocm_api_token():
-    if not os.path.isfile('ocm_token.txt'):
-        run_command(f'script/./get_ocm_token.sh')
-    ocm_api_token = str(open('ocm_token.txt').read()).strip('\n')
-    print('len(ocm_api_token)', len(ocm_api_token))
-    return ocm_api_token
-def sync_hcp_node_pools(cluster:oc_cluster):
-    api_server_base_url =  'https://api.openshift.com/api' if cluster.ocm_account == 'PROD' else 'https://api.stage.openshift.com/api'
-    ocm_api_token = get_ocm_api_token()
-    node_pools_response = requests.get(f'{api_server_base_url}/clusters_mgmt/v1/clusters/{cluster.id}/node_pools', headers={'Authorization': f'Bearer {ocm_api_token}'})
-    node_pools = node_pools_response.json()
-    node_pools = {node_pool['id']:node_pool['replicas'] for node_pool in node_pools['items'] if node_pool['kind'] == 'NodePool'}
-    totalNodes = 0
-    for id, replicas in node_pools.items():
-        newReplicas = replicas+1 if replicas <= 2 else replicas-1
-        payload = {'id': id,'labels':{},'taints':[],'replicas': newReplicas}
-        response = requests.patch(f'{api_server_base_url}/clusters_mgmt/v1/clusters/{cluster.id}/node_pools/{id}',
-                       data=json.dumps(payload),
-                     headers={'Authorization': f'Bearer {ocm_api_token}', 'Content-Type': 'application/json'})
-
-        print(f'synced the machine pool {id} with the new replica count {newReplicas} for cluster {cluster.name}')
-        print(response.status_code)
-        if response.status_code == 200:
-            totalNodes += newReplicas
-            print(f'now total nodes are {totalNodes}')
-
-        #instantly resetting the node count to avoid additional cost
-        payload = {'id': id,'labels':{},'taints':[],'replicas': replicas}
-        response = requests.patch(f'{api_server_base_url}/clusters_mgmt/v1/clusters/{cluster.id}/node_pools/{id}',
-                       data=json.dumps(payload),
-                     headers={'Authorization': f'Bearer {ocm_api_token}', 'Content-Type': 'application/json'})
-
-        print(f'reset the machine pool {id} with the original replica count {replicas} for cluster {cluster.name}')
-        print(response.status_code)
-        if response.status_code == 200:
-            totalNodes += replicas - newReplicas
-            print(f'now total nodes are back to {totalNodes}')
+def resume_cluster(cluster):
+    utils.run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
 
 
-    time.sleep(30)
-    return totalNodes
-
-def wait_for_rosa_cluster_to_be_ready(cluster:oc_cluster, worker_count:int):
-    time.sleep(15)
-    ec2_map = get_instances_for_region(cluster.region, 'running')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-    while len(InstanceIds) < worker_count:
-        print('Worker nodes starting, please wait...')
-        time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'running')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if worker_node_belongs_to_the_hcp_cluster(ec2_map[ec2_name], cluster.name)]
-
-    status_map = get_instance_status(cluster, InstanceIds)
-    while set(status_map.values()) != set(['ok_ok']):
-        print('Worker nodes initializing, please wait...')
-        time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
-
-def resume_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
+def resume_hypershift_cluster(cluster:utils.OcCluster, ec2_stopped_map:dict, ec2_running_map=None, wait_for_ready=True, attempts:int=0):
     ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
+
+    # get all stopped instances associated with this cluster
+    instances_stopped = [ec2_stopped_map[worker_node] for worker_node in ec2_stopped_map
+                         if utils.worker_node_belongs_to_the_hcp_cluster(ec2_stopped_map[worker_node], cluster.name)]
+    instances_stopped_ids = [v['InstanceId'] for v in instances_stopped]
+
+    # get all running instances associated with this cluster
+    if ec2_running_map is not None:
+        instances_running = [ec2_running_map[worker_node] for worker_node in ec2_running_map
+                               if utils.worker_node_belongs_to_the_hcp_cluster(ec2_running_map[worker_node], cluster.name)]
+    else:
+        instances_running = []
+
+    # get the requested node pools for this cluster from OCM
+    node_pool_information = get_ocm_node_pool_information(cluster)
+
+    # get the number of instances requested per instance type
+    instance_type_counts = {}
+    for _, node_pool_info in node_pool_information.items():
+        if node_pool_info["instance_type"] not in instance_type_counts:
+            instance_type_counts[node_pool_info["instance_type"]] = node_pool_info["replicas"]
+        else:
+            instance_type_counts[node_pool_info["instance_type"]] += node_pool_info["replicas"]
+
+    # see if we've got the right number of each type of instance
+    correct_numbers_of_each_node_type = True
+    for instance_type, desired_instance_type_count in instance_type_counts.items():
+        _, stopped_count = filter_instances_and_get_count(instances_stopped, instance_type)
+        _, running_count = filter_instances_and_get_count(instances_running, instance_type)
+        if stopped_count + running_count != desired_instance_type_count:
+            correct_numbers_of_each_node_type = False
+    total_requested_nodes = sum(v['replicas'] for v in node_pool_information.values())
+
+    if not correct_numbers_of_each_node_type:
+        fix_hcp_node_pool_miscount(ec2_client, cluster, node_pool_information, instances_running, instances_stopped)
+
+    elif correct_numbers_of_each_node_type and len(instances_stopped) > 0:
+        print(f'\tStarting stopped instances of cluster {cluster.name}: {instances_stopped_ids}', flush=True)
+
+        failed_starts = 0
+        for stopped_node in list(instances_stopped_ids):
+            try:
+                ec2_client.start_instances(InstanceIds=[stopped_node])
+            except botocore.exceptions.ClientError as e:
+                print(f"\tError starting instance {stopped_node}: {e}", flush=True)
+                print(f"\tTerminating unstartable instance {stopped_node}, will fall back to OCM provisioning", flush=True)
+                ec2_client.terminate_instances(InstanceIds=[stopped_node])
+                instances_stopped_ids.remove(stopped_node)
+                instances_stopped = [i for i in instances_stopped if i["InstanceId"] != stopped_node]
+                failed_starts += 1
+
+        if failed_starts > 0:
+            fix_hcp_node_pool_miscount(ec2_client, cluster, node_pool_information, instances_running, instances_stopped)
+
+    else:
+        print(f'All instances for cluster {cluster.name} are already running or initializing.', flush=True)
+
+    if wait_for_ready:
+        needs_retry = wait_for_rosa_cluster_to_be_ready(cluster, total_requested_nodes)
+        if needs_retry:
+            if attempts < 3:
+                ec2_stopped_map, ec2_running_map = utils.get_stopped_and_running_ec2_maps_for_cluster(cluster)
+                resume_hypershift_cluster(cluster, ec2_running_map, ec2_running_map, attempts+1)
+            else:
+                raise TimeoutError("Could not fix node pool issues, cluster is not resumable.")
+
+        print(f'Done resuming the cluster {cluster.name}', flush=True)
+
+
+
+def get_api_server_base_url(ocm_account: str):
+    return 'https://api.openshift.com/api' if ocm_account == 'PROD' else 'https://api.stage.openshift.com/api'
+
+
+def get_ocm_node_pool_information(cluster:utils.OcCluster) -> dict:
+    """
+    Get the requested node pool size and instance kind for each node pool in a cluster
+
+    Returns a dict of node pool ID - > {"replicas": requested replica count, "instance_type": AWS instance type}
+
+    e.g.,:
+    {"workers": {"replicas": 2, "instance_type": "m5.2xlarge"}
+    """
+    api_server_base_url = get_api_server_base_url(cluster.ocm_account)
+    ocm_api_token = utils.get_ocm_api_token()
+    node_pools_response = requests.get(f'{api_server_base_url}/clusters_mgmt/v1/clusters/{cluster.id}/node_pools',
+                                       headers={'Authorization': f'Bearer {ocm_api_token}'})
+    node_pools = node_pools_response.json()
+    node_pool_dict = {}
+
+    for node_pool in node_pools["items"]:
+        if node_pool['kind'] == 'NodePool':
+            if "replicas" in node_pool:
+                replicas = node_pool['replicas']
+            elif "autoscaling" in node_pool and "min_replica" in node_pool["autoscaling"]:
+                replicas = node_pool['autoscaling']['min_replica']
+            else:
+                raise KeyError(f"Retrieved node pool information did not report a desired replica count, instead received: {node_pool}")
+
+            if "aws_node_pool" in node_pool and "instance_type" in node_pool["aws_node_pool"]:
+                instance_type = node_pool["aws_node_pool"]["instance_type"]
+            else:
+                raise KeyError(f"Retrieved node pool information did not report a replica count, instead received: {node_pool}")
+
+            if "status" in node_pool and "current_replicas" in node_pool["status"]:
+                current_replicas = node_pool["status"]["current_replicas"]
+            else:
+                raise KeyError(f"Retrieved node pool information did not report a current replica count, instead received: {node_pool}")
+
+            node_pool_dict[node_pool['id']] = {"replicas": replicas, "instance_type": instance_type, "current_replicas": current_replicas}
+
+    return node_pool_dict
+
+
+def set_node_pool_to_n_replicas(url: str, token: str, cluster_id: str, node_pool_id, n_replicas: int):
+    """
+    Update a node to pool to the requested replica count
+    """
+    payload = {'id': node_pool_id, 'labels': {}, 'taints': [], 'replicas': n_replicas}
+    response = requests.patch(f'{url}/clusters_mgmt/v1/clusters/{cluster_id}/node_pools/{node_pool_id}',
+                              data=json.dumps(payload),
+                              headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'})
+    if response.status_code != 200:
+        raise RuntimeError(f"Could not set node pool {node_pool_id} replicas to {n_replicas}, error {response.status_code}: {response.text}")
+
+
+def filter_instances_and_get_count(instance_list, instance_type):
+    """
+    Helper function to return:
+        - the sublist of instances that match a specified instance type
+        - the count of such instances
+    """
+    matching_ids = []
+    for n in instance_list:
+        if n["InstanceType"] == instance_type:
+            matching_ids.append(n["InstanceId"])
+    return matching_ids, len(matching_ids)
+
+
+def trigger_ocm_reprovision_of_missing_nodes(cluster, node_pool_setter: Callable, node_pool_id: str, instance_type:str, nodes_present: int, nodes_desired: int):
+    nodes_missing = nodes_desired - nodes_present
+
+    print(f"\tTemporarily increasing node pool {node_pool_id} to {nodes_desired + nodes_missing}",
+              flush=True)
+    node_pool_setter(node_pool_id, nodes_desired + nodes_missing)
+
+    node_pool_info = get_ocm_node_pool_information(cluster)
+    while not all(node_pool["current_replicas"]>=node_pool["replicas"] for node_pool_id, node_pool in node_pool_info.items()):
+        print(f"\tWaiting for new nodes to provision and register, currently have:", flush=True)
+        for node_pool_id, node_pool in node_pool_info.items():
+            print(f"\t\t- {node_pool_id}: {node_pool['current_replicas']}/{node_pool['replicas']}", flush=True)
+
+        node_pool_info = get_ocm_node_pool_information(cluster)
+        time.sleep(5)
+
+    # reset the machine pool back to the original node quantity
+    print(f"\tResetting node pool {node_pool_id} to {nodes_desired}", flush=True)
+    node_pool_setter(node_pool_id, nodes_desired)
+
+
+def robust_node_start(ec2_client, cluster, nodes_to_start: list[str], node_pool_setter: Callable, node_pool_id: str, instance_type: str, nodes_desired: int):
+    """ Try directly starting a list of node IDS, fallback to OCM provisioning if starting fails"""
+
+    successful_starts, failed_starts = 0, 0
+    for stopped_node in nodes_to_start:
+        try:
+            ec2_client.start_instances(InstanceIds=[stopped_node])
+            successful_starts += 1
+        except botocore.exceptions.ClientError as e:
+            print(f"\tError starting instance {stopped_node}: {e}", flush=True)
+            print(f"\tTerminating unstartable instance {stopped_node}, will fall back to OCM provisioning", flush=True)
+            ec2_client.terminate_instances(InstanceIds=[stopped_node])
+            failed_starts += 1
+
+    if failed_starts > 0:
+        trigger_ocm_reprovision_of_missing_nodes(
+            cluster=cluster,
+            node_pool_setter=node_pool_setter,
+            node_pool_id=node_pool_id,
+            instance_type=instance_type,
+            nodes_present=nodes_desired - failed_starts,
+            nodes_desired=nodes_desired
+        )
+
+
+
+def fix_hcp_node_pool_miscount(ec2_client, cluster:utils.OcCluster, node_pool_information: dict, running_instances: list, stopped_instances: list):
+    """
+    Fix a mismatch between the number of existing instances (running or stopped) and the desired
+    node pool size
+    """
+    api_server_base_url = get_api_server_base_url(cluster.ocm_account)
+    ocm_api_token = utils.get_ocm_api_token()
+    node_pool_setter = lambda np_id, n: set_node_pool_to_n_replicas(
+        url=api_server_base_url,
+        token=ocm_api_token,
+        cluster_id=cluster.id,
+        node_pool_id=np_id,
+        n_replicas=n)
+
+    for node_pool_id, node_pool_info in node_pool_information.items():
+        n_requested_nodes = node_pool_info['replicas']
+
+        matching_running_ids, n_matching_running_nodes = filter_instances_and_get_count(running_instances, node_pool_info['instance_type'])
+        matching_stopped_ids, n_matching_stopped_nodes = filter_instances_and_get_count(stopped_instances, node_pool_info['instance_type'])
+        n_actual_nodes = n_matching_running_nodes + n_matching_stopped_nodes
+
+        if n_actual_nodes<n_requested_nodes:
+            # If number of actual nodes is too small:
+            #   1) start all stopped nodes
+            #   2) prune the machine pool down to the existing node count
+            #   3) reset it back to the desired amount,
+            # The prune+reset should trigger the creation of the missing nodes
+            print(f"=== Rectifying node undersupply for node pool {node_pool_id} ({node_pool_info['instance_type']}) (have {n_actual_nodes} nodes, want {n_requested_nodes}) ===", flush=True)
+
+            if n_matching_stopped_nodes > 0:
+                print(f"\tStarting stopped nodes of node pool {node_pool_id}: {matching_stopped_ids }", flush=True)
+                for stopped_node in matching_stopped_ids:
+                    try:
+                        ec2_client.start_instances(InstanceIds=[stopped_node])
+                    except botocore.exceptions.ClientError as e:
+                        print(f"\tError starting instance {stopped_node}: {e}", flush=True)
+                        print(f"\tTerminating unstartable instance {stopped_node}, will fall back to OCM provisioning",
+                              flush=True)
+                        ec2_client.terminate_instances(InstanceIds=[stopped_node])
+                        n_actual_nodes -= 1
+
+            trigger_ocm_reprovision_of_missing_nodes(
+                cluster=cluster,
+                node_pool_setter=node_pool_setter,
+                node_pool_id=node_pool_id,
+                instance_type=node_pool_info["instance_type"],
+                nodes_present=n_actual_nodes,
+                nodes_desired=n_requested_nodes
+            )
+
+        elif n_actual_nodes > n_requested_nodes:
+            # if number of actual nodes is too big, where D=desired node count, R=running node count, S=stopped_node count
+            #   1) If we already have sufficient running nodes for the requested node count (R>D):
+            #     a) terminate all stopped nodes S
+            #     b) terminate any extra running nodes R-D
+            #      Outcome: R-(R-D) + (S-S) = D nodes
+            #   2) Else:
+            #     a) leave all running nodes R running
+            #     b) terminate (R+S)-D stopped nodes
+            #     c) start the remaining S-((R+S)-D) nodes
+            #       Outcome: R + (S - ((R+S)-D)) = D nodes
+
+            print(f"=== Rectifying node oversupply for node pool {node_pool_id} (have {n_actual_nodes} nodes, want {n_requested_nodes}) ===", flush=True)
+
+            # if we've got more running nodes than needed, terminate all stopped nodes and the extra running
+            if n_matching_running_nodes>=n_requested_nodes:
+                if n_matching_running_nodes>n_requested_nodes:
+                    running_nodes_to_terminate = matching_running_ids[n_requested_nodes:]
+                    print(f"\tTerminating extra running instances: {running_nodes_to_terminate}", flush=True)
+                    ec2_client.terminate_instances(InstanceIds=running_nodes_to_terminate)
+
+                if n_matching_stopped_nodes>0:
+                    print(f"\tTerminating all stopped instances: {matching_stopped_ids}", flush=True)
+                    ec2_client.terminate_instances(InstanceIds=matching_stopped_ids)
+            else:
+                # some combination of running and stopped nodes overshoots the desired amount
+                overshoot = n_actual_nodes - n_requested_nodes
+
+                # since we've checked that there are fewer running nodes than desired
+                # we can always fix the overshoot by terminating stopped nodes
+                stopped_nodes_to_terminate = matching_stopped_ids[:overshoot]
+                print(f"\tTerminating extra stopped instances: {stopped_nodes_to_terminate}", flush=True)
+                ec2_client.terminate_instances(InstanceIds=stopped_nodes_to_terminate)
+
+                # start remaining instances
+                stopped_nodes_to_start = matching_stopped_ids[overshoot:]
+                print(f"\tStarting remaining stopped instances: {stopped_nodes_to_start}", flush=True)
+                robust_node_start(
+                    ec2_client=ec2_client,
+                    cluster=cluster,
+                    nodes_to_start=stopped_nodes_to_start,
+                    instance_type=node_pool_info["instance_type"],
+                    node_pool_setter=node_pool_setter,
+                    node_pool_id=node_pool_id,
+                    nodes_desired=n_requested_nodes
+                )
+
+        else:
+            #  node pool has the correct number of nodes
+            pass
+
+
+def wait_for_rosa_cluster_to_be_ready(cluster:utils.OcCluster, worker_count:int, timeout_seconds:int=1200) -> bool:
+    deadline = time.time() + timeout_seconds
+
+    time.sleep(15)
+    ec2_map = utils.get_instances(cluster=cluster)
+    states = utils.group_ec2_instances_by_state(ec2_map)
+
+    print(f"=== Waiting for {worker_count} worker nodes to start ===", flush=True)
+    while len(states[InstanceState.running]) < worker_count:
+        if time.time() > deadline:
+            raise TimeoutError(f"Timed out waiting for {worker_count} nodes to start (only {len(states[InstanceState.running])} running after {timeout_seconds}s)")
+        print(f"\t{len(states[InstanceState.running])}/{worker_count} nodes running:", flush=True)
+        utils.print_ec2_instance_state(ec2_map, prefix="\t\t", filtered_states=[InstanceState.terminated])
+
+        time.sleep(5)
+
+        ec2_map = utils.get_instances(cluster=cluster)
+        states = utils.group_ec2_instances_by_state(ec2_map)
+
+        # check if there's enough starting nodes - no point waiting if not.
+        starting_nodes = len(states[InstanceState.running]) + len(states[InstanceState.pending])
+        if starting_nodes < worker_count:
+            print(f"\tWARNING: There are only {starting_nodes} nodes in a pending or running state, "
+                  f"the cluster likely needs further intervention. The script will wait one minute to see if more"
+                  f" pending nodes arrive, and if not will attempt to repair the cluster nodes", flush=True)
+            insufficent_node_timeout = time.time()
+        else:
+            insufficent_node_timeout = None
+
+        # terminate the wait loop if it's hopeless
+        if insufficent_node_timeout is not None and time.time() > (insufficent_node_timeout + 60):
+            print("\tNo new pending nodes arrived- waiting longer is probably not going to be helpful. Beginning node pool repair.", flush=True)
+            return True # need to retry resumption
+
+
+
+    print("\tAll nodes running", flush=True)
+    status_map = get_instance_and_system_status(cluster, states[InstanceState.running])
+    while set(status_map.values()) != set(['ok_ok']):
+        if time.time() > deadline:
+            raise TimeoutError(f"Timed out waiting for nodes to report ok status after {timeout_seconds}s. Current: {status_map}")
+        print("\tWaiting for all worker nodes to report status=ok_ok:", flush=True)
+        for k,v in status_map.items():
+            print(f"\t\t- {k}: {v}", flush=True)
+        time.sleep(5)
+        status_map = get_instance_and_system_status(cluster, states[InstanceState.running])
+
+    return False
+
+def resume_ipi_cluster(cluster:utils.OcCluster, ec2_map:dict, wait_for_ready=True):
+
+    # The startswith pre-filter may miss IPI nodes — it caused a bug in HCP clusters.
+    # If IPI nodes aren't being correctly resumed, investigate this filter first.
+    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
+
+    ec2_client = boto3.client('ec2', region_name=cluster.region)
+    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes
+                   if utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
+
     if len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
+        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds, flush=True)
         worker_count = len(InstanceIds)
         ec2_client.start_instances(InstanceIds=InstanceIds)
-        wait_for_ipi_cluster_to_be_ready(cluster, worker_count)
-        print(f'Done resuming the cluster {cluster.name}')
+        if wait_for_ready:
+            wait_for_ipi_cluster_to_be_ready(cluster, worker_count)
+        print(f'Done resuming the cluster {cluster.name}', flush=True)
     else:
-        print(f'Cluster {cluster.name} is already running.')
+        print(f'Cluster {cluster.name} is already running.', flush=True)
 
-def wait_for_ipi_cluster_to_be_ready(cluster:oc_cluster, worker_count:int):
+
+def wait_for_ipi_cluster_to_be_ready(cluster:utils.OcCluster, worker_count:int, timeout_seconds:int=1200):
+    deadline = time.time() + timeout_seconds
     time.sleep(15)
-    ec2_map = get_instances_for_region(cluster.region, 'running')
-    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-') and worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+    ec2_map = utils.get_instances(cluster=cluster, current_state=InstanceState.running)
+    InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map
+                   if ec2_name.startswith(f'{cluster.internal_name}-')
+                   and utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
     while len(InstanceIds) < worker_count:
-        print('Worker nodes starting, please wait...')
+        if time.time() > deadline:
+            raise TimeoutError(f"Timed out waiting for {worker_count} nodes to start (only {len(InstanceIds)} running after {timeout_seconds}s)")
+        print(f'\t{len(InstanceIds)}/{worker_count} nodes running, will check again in 5s...', flush=True)
         time.sleep(5)
-        ec2_map = get_instances_for_region(cluster.region, 'running')
-        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-') and worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+        ec2_map = utils.get_instances(cluster=cluster, current_state=InstanceState.running)
+        InstanceIds = [ec2_map[ec2_name]['InstanceId'] for ec2_name in ec2_map
+                       if ec2_name.startswith(f'{cluster.internal_name}-')
+                       and utils.worker_node_belongs_to_the_ipi_cluster(ec2_map[ec2_name], cluster.internal_name)]
+    print("All nodes running", flush=True)
 
-    status_map = get_instance_status(cluster, InstanceIds)
+    status_map = get_instance_and_system_status(cluster, InstanceIds)
     while set(status_map.values()) != set(['ok_ok']):
-        print('Worker nodes initializing, please wait...')
+        if time.time() > deadline:
+            raise TimeoutError(f"Timed out waiting for nodes to report ok status after {timeout_seconds}s. Current: {status_map}")
+        print('Worker nodes initializing, please wait...', flush=True)
         time.sleep(5)
-        status_map = get_instance_status(cluster, InstanceIds)
+        status_map = get_instance_and_system_status(cluster, InstanceIds)
 
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
 
-def get_instance_status(cluster:oc_cluster, InstanceIds:list):
+def get_instance_and_system_status(cluster:utils.OcCluster, InstanceIds:list):
     ec2_client = boto3.client('ec2', region_name=cluster.region)
     ec2_map = ec2_client.describe_instance_status(InstanceIds=InstanceIds)
     status_map = {ec2['InstanceId']:f"{ec2['InstanceStatus']['Status']}_{ec2['SystemStatus']['Status']}" for ec2 in ec2_map['InstanceStatuses']}
     return status_map
 
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
 
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
-
+# === MAIN FUNCTION ================================================================================
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Hibernate the given cluster"
+        description="Resume the given cluster"
     )
 
     parser.add_argument("--cluster_name", dest="cluster_name",
@@ -229,51 +444,35 @@ def parse_arguments():
 
     parser.add_argument("--ocm_account", dest="ocm_account",
                         action="store",
-                        help="Provide the OCM account which cluster belongs to , possible values PROD or STAGE", required=True)
+                        help="Provide the OCM account which cluster belongs to, possible values PROD or STAGE", required=True)
     args = parser.parse_args()
 
     return args
-def sanitize_cluster_name(cluster_name:str):
-    if cluster_name.count('-') == 4:
-        cluster_name = cluster_name[:28]
-    return cluster_name
+
 
 def main():
     args = parse_arguments()
     args.ocm_account = args.ocm_account.split(' ')[0]
-    clusters = []
 
-    get_all_cluster_details(args.ocm_account, clusters)
+    print("=== Getting details for all clusters ===", flush=True)
+    clusters = get_all_cluster_details(args.ocm_account)
 
     available_clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-    target_cluster = [cluster for cluster in available_clusters if cluster.name == sanitize_cluster_name(args.cluster_name)]
+    target_cluster = [cluster for cluster in available_clusters if cluster.name == utils.sanitize_cluster_name(args.cluster_name)]
     if len(target_cluster) > 1:
-        sys.exit("More than one clusters found with give name.")
+        sys.exit("More than one clusters found with given name.")
 
     if not target_cluster:
         sys.exit("No cluster found with given name.")
 
     if len(target_cluster) == 1:
         target_cluster = target_cluster[0]
-        ec2_map = get_instances_for_region(target_cluster.region, 'stopped')
-        ec2_running_map = get_instances_for_region(target_cluster.region, 'running')
-        print('starting to resume ', target_cluster.name)
-        if target_cluster.hcp == "false":
-            if target_cluster.type == 'ocp':
-                resume_ipi_cluster(target_cluster, ec2_map)
-            else:
-                if target_cluster.status == "hibernating":
-                    resume_cluster(target_cluster)
-                else:
-                    print(f'Cluster {target_cluster.name} is not in hibernating state')
-        else:
-            resume_hypershift_cluster(target_cluster, ec2_map, ec2_running_map)
-        print('starting the smartsheet update')
-        ca.main()
-        print('Resumed the cluster:')
-        print(target_cluster.name)
+        resume_generic_cluster(target_cluster)
 
+        print("=== Updating cluster status in Smartsheet ===")
+        ca.main(cluster_list=[target_cluster], needs_data_refresh=False, allow_smartsheet_deletion=False)
 
+        print(f'Resumed cluster: {target_cluster.name}', flush=True)
 
 
 if __name__ == '__main__':

--- a/src/resume_clusters_daily.py
+++ b/src/resume_clusters_daily.py
@@ -1,220 +1,35 @@
-import json
-import boto3
-import time, datetime
-import os
-import smartsheet
-import re
+import utils
+from hibernate_cluster import get_all_cluster_details
+from resume_cluster import resume_generic_cluster
 
-
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.hibernate_error = ''
-        self.ocm_account = ocm_account
-        self.inactive_hours_start = None
-        self.inactive_hours_end = None
-
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance: dict, cluster_name: str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def resume_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    if len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.terminate_instances(InstanceIds=InstanceIds)
-        print(f'Done resuming the cluster {cluster.name}')
-        time.sleep(5)
-    else:
-        print(f'Cluster {cluster.name} is already running.')
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_all_cluster_details(ocm_account: str, clusters: dict):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-
-
-def get_cluster_list(ocm_account: str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-
-
-
-def get_clusters_from_smartsheet():
-    column_map = {}
-    smart = smartsheet.Smartsheet()
-    # response = smart.Sheets.list_sheets()
-    sheed_id = 7086931905040260
-    inactive_hours_start_index, inactive_hours_end_index = 5, 6
-    sheet = smart.Sheets.get_sheet(sheed_id)
-
-    # get existing data
-    smartsheet_data = {
-        row.cells[0].value: [row.cells[inactive_hours_start_index].value, row.cells[inactive_hours_end_index].value]
-        for row in sheet.rows}
-    return smartsheet_data
-
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-
-def good_time_to_resume_cluster(inactive_hours_end: str):
-    buffer_hours = 2
-    buffer_seconds = buffer_hours * 60 * 60
-    day_start_time = '00:00:00'
-    day_end_time = '23:59:59'
-
-    try:
-        inactive_hours_end = datetime.datetime.strptime(inactive_hours_end, '%H:%M:%S')
-    # if the inactive hours start is misconfigured, default to keeping cluster hibernated
-    except ValueError:
-        return False
-
-    current_utc_time = datetime.datetime.strptime(datetime.datetime.now(datetime.timezone.utc).strftime('%H:%M:%S'),
-                                     '%H:%M:%S')
-    day_start_time = datetime.datetime.strptime(day_start_time, '%H:%M:%S')
-    day_end_time = datetime.datetime.strptime(day_end_time, '%H:%M:%S')
-    diff = (current_utc_time - inactive_hours_end).total_seconds()
-    if diff < 0 and 24 - buffer_hours < inactive_hours_end.hour <= 24 and 0 <= current_utc_time.hour <= buffer_hours:
-        diff = (day_end_time - inactive_hours_end).total_seconds() + (
-                    current_utc_time - day_start_time).total_seconds()
-
-    return 0 <= diff <= buffer_seconds
-
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
-
-def resume_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
-    if len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.start_instances(InstanceIds=InstanceIds)
-        print(f'Done resuming the cluster {cluster.name}')
-    else:
-        print(f'Cluster {cluster.name} is already running.')
 
 def main():
-    ec2_instances = {}
-    get_all_instances(ec2_instances, 'stopped')
-
-    clusters: list[oc_cluster] = []
+    print("=== Getting details for all clusters ===", flush=True)
+    clusters: list[utils.OcCluster] = []
     ocm_accounts = ['PROD', 'STAGE']
-
     for ocm_account in ocm_accounts:
-        get_all_cluster_details(ocm_account, clusters)
+        clusters += get_all_cluster_details(ocm_account)
 
-    smartsheet_data = get_clusters_from_smartsheet()
+    print("=== Getting all clusters from Smartsheet ===", flush=True)
+    smartsheet_data = utils.get_clusters_from_smartsheet()
     for cluster in clusters:
         if cluster.id in smartsheet_data:
-            smartsheet_cluster_info = smartsheet_data[cluster.id]
+            cluster_inactive_hours_end = smartsheet_data[cluster.id][utils.ClusterSmartsheetColumns.INACTIVE_HOURS_END]
 
-            if smartsheet_cluster_info[1]:
-                if smartsheet_cluster_info[1].count(':') < 1:
-                    print(f'Invalid inactive_hours_end {smartsheet_cluster_info[1]} for cluster {cluster.name}')
+            if cluster_inactive_hours_end:
+                if cluster_inactive_hours_end.count(':') < 1:
+                    print(f'Invalid inactive_hours_end {cluster_inactive_hours_end} for cluster {cluster.name}')
                     continue
-                if smartsheet_cluster_info[1].count(':') == 1:
-                    smartsheet_cluster_info[1] += ':00'
-                cluster.inactive_hours_end = smartsheet_cluster_info[1]
+                if cluster_inactive_hours_end.count(':') == 1:
+                    cluster_inactive_hours_end += ':00'
+                cluster.inactive_hours_end = cluster_inactive_hours_end
 
-    hibernated_clusters = []
+    print("=== Resuming clusters ===", flush=True)
+    resumed_clusters = []
     for cluster in clusters:
-        if cluster.inactive_hours_end and good_time_to_resume_cluster(cluster.inactive_hours_end):
-            if cluster.hcp == "false":
-                if cluster.type == 'ocp':
-                    resume_ipi_cluster(cluster, ec2_instances[cluster.region])
-                    print("IPI - ", cluster.name)
-                else:
-                    resume_cluster(cluster)
-                    print("OSD or ROSA Classic - ", cluster.name)
-            else:
-                resume_hypershift_cluster(cluster, ec2_instances[cluster.region])
-                print("Hypershift cluster - ", cluster.name)
-            hibernated_clusters.append(cluster.__dict__)
-
-    # print(json.dumps(hibernated_clusters, indent=4))
+        if cluster.inactive_hours_end and utils.within_two_hour_window_after(cluster.inactive_hours_end, default_decision=False):
+            resume_generic_cluster(cluster)
+            resumed_clusters.append(cluster.__dict__)
 
 
 if __name__ == '__main__':

--- a/src/resume_clusters_weekend.py
+++ b/src/resume_clusters_weekend.py
@@ -1,133 +1,29 @@
 import json
-import time
 
 import boto3
-import os
+import utils
+from resume_cluster import resume_generic_cluster
 
-# need to sync the list with latest status, and resume it only if status is Hibernating
-
-class oc_cluster:
-    def __init__(self, cluster_detail):
-        self.id = cluster_detail['id']
-        self.name = cluster_detail['name']
-        self.internal_name = cluster_detail['internal_name']
-        self.api_url = cluster_detail['api_url']
-        self.ocp_version = cluster_detail['ocp_version']
-        self.type = cluster_detail['type']
-        self.hcp = cluster_detail['hcp']
-        self.cloud_provider = cluster_detail['cloud_provider']
-        self.region = cluster_detail['region']
-        self.status = cluster_detail['status']
-        self.resume_error = ''
-        self.ocm_account = cluster_detail['ocm_account']
-def run_command(command):
-    print(command)
-    output = os.popen(command).read()
-    # print(output)
-    return output
 
 def get_last_hibernated():
     s3 = boto3.client('s3')
     s3.download_file('rhods-devops', 'Cloud-Cost-Optimization/Weekend-Hibernation/hibernated_latest.json', 'hibernated_latest.json')
 
-def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str):
-    """Check if an EC2 instance belongs to a specific HCP cluster """
-    result = False
-    for tag in ec2_instance['Tags']:
-        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
-            result = True
-            break
-    return result
-
-def resume_hypershift_cluster(cluster:oc_cluster, ec2_map:dict):
-    # ec2_map = ec2_instances[cluster.region]
-
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_hcp_cluster(ec2_map[worker_node], cluster.name)]
-    if len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.terminate_instances(InstanceIds=InstanceIds)
-        print(f'Done resuming the cluster {cluster.name}')
-        time.sleep(5)
-    else:
-        print(f'Cluster {cluster.name} is already running.')
-
-
-
-
-def hibernate_cluster(cluster: oc_cluster):
-    run_command(f'script/./hybernate_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def resume_cluster(cluster: oc_cluster):
-    run_command(f'script/./resume_cluster.sh {cluster.ocm_account} {cluster.id}')
-
-def get_instances_for_region(region, current_state):
-    ec2_client = boto3.client('ec2', region_name=region)
-    filters = [{'Name': 'instance-state-name', 'Values': [current_state]}]
-    ec2_map = ec2_client.describe_instances(Filters=filters, MaxResults=1000)
-    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
-    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
-    ec2_map = {list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))[0]['Value']: instance for instance in
-               ec2_map if list(filter(lambda obj: obj['Key'] == 'Name', instance['Tags']))}
-    print(region, len(ec2_map))
-    return ec2_map
-
-def get_all_instances(ec2_instances, current_state):
-    client = boto3.client('ec2', region_name='us-east-1')
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
-    for region in regions:
-        ec2_instances[region] = get_instances_for_region(region, current_state)
-
-def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str):
-    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
-    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
-    for key, value in tags.items():
-        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
-            result = result and True
-            break
-    return result
-
-def resume_ipi_cluster(cluster:oc_cluster, ec2_map:dict):
-    # print([name for name in ec2_map])
-    worker_nodes = [ec2_name for ec2_name in ec2_map if ec2_name.startswith(f'{cluster.internal_name}-')]
-    ec2_client = boto3.client('ec2', region_name=cluster.region)
-    InstanceIds = [ec2_map[worker_node]['InstanceId'] for worker_node in worker_nodes if worker_node_belongs_to_the_ipi_cluster(ec2_map[worker_node], cluster.internal_name)]
-    if len(InstanceIds) > 0:
-        print(f'Starting Worker Instances of cluster {cluster.name}', InstanceIds)
-        worker_count = len(InstanceIds)
-        ec2_client.start_instances(InstanceIds=InstanceIds)
-        print(f'Done resuming the cluster {cluster.name}')
-    else:
-        print(f'Cluster {cluster.name} is already running.')
 
 def main():
-    ec2_instances = {}
-    get_all_instances(ec2_instances, 'stopped')
     get_last_hibernated()
+
+    print("=== Identifying clusters to resume ===", flush=True)
     clusters_to_resume = []
     clusters = json.load(open('hibernated_latest.json'))
     for cluster in clusters:
-        clusters_to_resume.append(oc_cluster(cluster))
+        clusters_to_resume.append(utils.OcCluster(cluster))
+
+    print("=== Resuming clusters ===", flush=True)
     resumed_clusters = []
     for cluster in clusters_to_resume:
-        print('starting with', cluster.name, cluster.type)
-        if cluster.hcp == "false":
-            if cluster.type == 'ocp':
-                resume_ipi_cluster(cluster, ec2_instances[cluster.region])
-                print("IPI - ", cluster.name)
-            else:
-                resume_cluster(cluster)
-                print("OSD or ROSA Classic - ", cluster.name)
-        else:
-            resume_hypershift_cluster(cluster, ec2_instances[cluster.region])
-            print("Hypershift cluster - ", cluster.name)
+        resume_generic_cluster(cluster)
         resumed_clusters.append(cluster.__dict__)
-        print(f'Hibernated {cluster.name}')
-
-    # print(json.dumps(resumed_clusters, indent=4))
 
 
 if __name__ == '__main__':

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,339 @@
+import datetime
+import json
+import os
+import re
+import time
+from enum import Enum
+from typing import Union, Optional
+
+import boto3
+import smartsheet
+
+
+# === CLUSTER DATA CLASS ===========================================================================
+class OcCluster:
+    def __init__(self, cluster_detail, ocm_account=None):
+        if isinstance(cluster_detail, dict):
+            self.id = cluster_detail['id']
+            self.name = cluster_detail['name']
+            self.internal_name = cluster_detail.get('internal_name', cluster_detail['name'])
+            self.api_url = cluster_detail['api_url']
+            self.ocp_version = cluster_detail['ocp_version']
+            self.type = cluster_detail['type']
+            self.hcp = cluster_detail['hcp']
+            self.cloud_provider = cluster_detail['cloud_provider']
+            self.region = cluster_detail['region']
+            self.status = cluster_detail['status']
+            self.ocm_account = cluster_detail.get('ocm_account', ocm_account)
+        else:
+            details = cluster_detail.split(' ')
+            details = [detail for detail in details if detail]
+            self.id = details[0]
+            self.name = details[1]
+            self.internal_name = details[1]
+            self.api_url = details[2]
+            self.ocp_version = details[3]
+            self.type = details[4]
+            self.hcp = details[5]
+            self.cloud_provider = details[6]
+            self.region = details[7]
+            self.status = details[8]
+            self.ocm_account = ocm_account
+        self.nodes = []
+        self.hibernate_error = ''
+        self.resume_error = ''
+        self.inactive_hours_start = None
+        self.inactive_hours_end = None
+        self.creation_date = ''
+        self.creator_name = ''
+        self.creator_email = ''
+
+
+# === EC2 INSTANCE CHECKS ===============================================================================
+class InstanceState(Enum):
+    """All possible AWS EC2 instance states"""
+    pending="pending"
+    running="running"
+    stopped="stopped"
+    stopping="stopping"
+    shutting_down="shutting-down"
+    terminated="terminated"
+
+
+def worker_node_belongs_to_the_hcp_cluster(ec2_instance:dict, cluster_name:str) -> bool:
+    """Check if an EC2 instance belongs to a specific HCP cluster """
+    result = False
+    for tag in ec2_instance['Tags']:
+        if tag['Key'] == 'api.openshift.com/name' and tag['Value'] == cluster_name:
+            result = True
+            break
+    return result
+
+
+def worker_node_belongs_to_the_ipi_cluster(ec2_instance:dict, cluster_name:str) -> bool:
+    """Check if an EC2 instance belongs to a specific IPI cluster """
+    tags = {tag['Key']:tag['Value'] for tag in ec2_instance['Tags']}
+    result = 'red-hat-clustertype' not in tags and 'api.openshift.com/name' not in tags
+    for key, value in tags.items():
+        if key.startswith(f'kubernetes.io/cluster/{cluster_name}-') and value == 'owned':
+            result = result and True
+            break
+    return result
+
+
+def get_all_instances(ec2_instances, current_state: Union[list[InstanceState], InstanceState])-> dict[str: dict]:
+    """Get all EC2 instances in a specific state"""
+    client = boto3.client('ec2', region_name='us-east-1')
+    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
+    for region in regions:
+        ec2_instances[region] = get_instances(region=region, current_state=current_state)
+
+
+def _get_paginated_instances(ec2_client, filters):
+    paginator = ec2_client.get_paginator('describe_instances')
+    instances = []
+    for page in paginator.paginate(Filters=filters):
+        for reservation in page['Reservations']:
+            instances.extend(reservation['Instances'])
+    return instances
+
+
+def get_instances(
+        cluster: OcCluster=None,
+        region: str=None,
+        current_state: Optional[Union[list[InstanceState], str]]=None,
+        cluster_name: Optional[Union[list[str], str]]=None,
+        instance_type: Optional[Union[list[str], str]]=None):
+    """Return all EC2 instances for a given region, with optional filters on
+    cluster, instance state, cluster name, and instance type
+    """
+
+    if cluster is None and region is None:
+        raise ValueError("get_instances() requires either cluster or region specified")
+
+    if cluster is not None:
+        region = cluster.region
+        cluster_name = [cluster.name]
+
+    ec2_client = boto3.client('ec2', region_name=region)
+
+    filters = []
+    if current_state is not None:
+        if not isinstance(current_state, list):
+            current_state = [current_state]
+        current_state = [s.value for s in current_state]
+        filters.append({'Name': 'instance-state-name', 'Values': current_state})
+
+    if cluster_name is not None:
+        if not isinstance(cluster_name, list):
+            cluster_name = [cluster_name]
+        filters.append({'Name': 'tag:api.openshift.com/name', "Values": cluster_name})
+
+    if instance_type is not None:
+        if not isinstance(instance_type, list):
+            instance_type = [instance_type]
+        filters.append({'Name': 'instance-type', 'Values': instance_type})
+
+    instances = _get_paginated_instances(ec2_client, filters)
+
+    # return a map of instances, keyed by their name tag
+    tagged_instances_map = {}
+    for instance in instances:
+        name_tags = [tag['Value'] for tag in instance.get("Tags", []) if tag['Key'] == 'Name']
+        if name_tags:
+            tagged_instances_map[name_tags[0]] = instance
+    return tagged_instances_map
+
+
+def get_stopped_and_running_ec2_maps_for_cluster(cluster: OcCluster):
+    return get_instances(
+        cluster=cluster,
+        current_state=[InstanceState.stopped, InstanceState.stopping]
+    ), get_instances(
+        cluster=cluster,
+        current_state=[InstanceState.running, InstanceState.pending]
+    )
+
+
+def group_ec2_instances_by_state(ec2_map) -> dict[InstanceState, list[str]]:
+    """Provide a map of state -> ec2 ids"""
+    states = {state: [] for state in InstanceState}
+    for ec2_name, ec2 in ec2_map.items():
+        states[InstanceState(ec2["State"]["Name"])].append(ec2['InstanceId'])
+    return states
+
+
+def get_instance_state_by_id(cluster, InstanceIds:list):
+    """Get the status of a specific set of InstanceIDs"""
+    ec2_client = boto3.client('ec2', region_name=cluster.region)
+    ec2_map = ec2_client.describe_instances(InstanceIds=InstanceIds)
+    ec2_map = [ec2 for ec2 in ec2_map['Reservations']]
+    ec2_map = [instance for ec2 in ec2_map for instance in ec2['Instances']]
+    status_map = {ec2['InstanceId']: InstanceState(ec2['State']['Name']) for ec2 in ec2_map}
+    return status_map
+
+
+def get_ec2_instance_state(ec2_map: dict) -> dict[str, InstanceState]:
+    """Get a map of ec2 instances and their state, if an ec2_map has already been retrieved"""
+    return {ec2['InstanceId']: InstanceState(ec2["State"]["Name"]) for ec2_name, ec2 in ec2_map.items()}
+
+
+def print_ec2_instance_state(ec2_map: dict, prefix="", filtered_states=None) -> None:
+    """Print ec2 instances and their state"""
+    if filtered_states is None:
+        filtered_states = []
+
+    instance_states = get_ec2_instance_state(ec2_map)
+
+    for instance, state in sorted(instance_states.items()):
+        if state not in filtered_states:
+            print(f"{prefix}- {instance}: {state.value}")
+
+
+# === SCRIPT CALLERS ===============================================================================
+def run_command(command):
+    """Run a shell command"""
+    output = os.popen(command).read()
+    return output
+
+
+def get_cluster_list(ocm_account:str):
+    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
+
+# === IPI UTILITIES ================================================================================
+def get_ipi_cluster_name(cluster):
+    if cluster.name.count('-') == 4:
+        try:
+            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
+            url = url.replace('Console URL:', '').strip()
+            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
+            if result:
+                cluster.internal_name = result.group(1)
+        except:
+            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
+
+
+# === VOLUME UTILITIES ==========================================================================
+def delete_volume(volume_id, region):
+    ec2_client = boto3.client('ec2', region_name=region)
+    for attempt in range(7):
+        try:
+            ec2_client.delete_volume(VolumeId=volume_id)
+            print(f'Deleted the volume {volume_id}', flush=True)
+            return
+        except:
+            time.sleep(5)
+    print(f"Failed to delete volume {volume_id}", flush=True)
+
+
+# === AUTH =========================================================================================
+def get_ocm_api_token():
+    if not os.path.isfile('ocm_token.txt'):
+        run_command(f'script/./get_ocm_token.sh')
+    ocm_api_token = str(open('ocm_token.txt').read()).strip('\n')
+    return ocm_api_token
+
+
+# === STRING UTILS =================================================================================
+def sanitize_cluster_name(cluster_name:str):
+    if cluster_name.count('-') == 4:
+        cluster_name = cluster_name[:28]
+    return cluster_name
+
+
+def check_if_given_tag_exists(tag_name, tags:list[dict]):
+    result = False
+    for tag in tags:
+        if tag['Key'] == tag_name:
+            result = True
+            break
+    return result
+
+
+# === SMARTSHEET UTILS =============================================================================
+class ClusterSmartsheetColumns(Enum):
+    ID=0
+    NAME=1
+    STATUS=2
+    TYPE=3
+    IS_HCP=4
+    INACTIVE_HOURS_START=5
+    INACTIVE_HOURS_END=6
+    OWNER=7
+    AGE=8
+    CREATION_DATE=9
+    REGION=10
+    PROVIDER=11
+    OCM_ACCOUNT=12
+
+
+def get_clusters_from_smartsheet():
+    smart = smartsheet.Smartsheet()
+    # response = smart.Sheets.list_sheets()
+    sheed_id = 7086931905040260
+    sheet = smart.Sheets.get_sheet(sheed_id)
+
+    # return requested data as a map of cluster ID -> {column_name: value}
+    smartsheet_data = {}
+    for row in sheet.rows:
+        row_data = {column: row.cells[column.value].value for column in ClusterSmartsheetColumns}
+        smartsheet_data[row_data[ClusterSmartsheetColumns.ID]] = row_data
+    return smartsheet_data
+
+
+def get_all_cluster_details(ocm_account:str, clusters:list):
+    get_cluster_list(ocm_account)
+    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
+    for cluster_detail in clusters_details:
+        cluster = OcCluster(cluster_detail, ocm_account)
+        if cluster.type == 'ocp':
+            get_ipi_cluster_name(cluster)
+        if cluster.cloud_provider == 'aws' and (
+                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
+            clusters.append(cluster)
+    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
+    update_cluster_details(clusters)
+
+
+def update_cluster_details(clusters:list[OcCluster]):
+    for cluster in clusters:
+        run_command(f'script/./get_cluster_details.sh {cluster.ocm_account} {cluster.id}')
+        details = json.load(open(f'{cluster.id}_details.json'))
+        cluster.creation_date = details['creation_date']
+        cluster.creator_name = details['creator_name']
+        if details['creator_email'] and details['creator_email'] != 'null':
+            cluster.creator_email = details['creator_email']
+            if '+' in cluster.creator_email:
+                cluster.creator_email = get_original_email_address(cluster.creator_email)
+
+
+def get_original_email_address(email:str):
+    parts = email.split('@')
+    original_prefix = parts[0].split('+')[0]
+    return f'{original_prefix}@{parts[1]}'
+
+
+# === TIME UTILS ===================================================================================
+def within_two_hour_window_after(action_timestamp: str, default_decision: bool):
+    """Checks if we're within a two-hour window AFTER the action timestamp """
+
+    buffer_hours = 2
+    buffer_seconds = buffer_hours * 60 * 60
+    day_start_time = '00:00:00'
+    day_end_time = '23:59:59'
+    try:
+        action_timestamp = datetime.datetime.strptime(action_timestamp, '%H:%M:%S')
+    # if the action timestamp is misconfigured, return the default_decision
+    except ValueError:
+        return default_decision
+
+    current_utc_time = datetime.datetime.strptime(datetime.datetime.now(datetime.timezone.utc).strftime('%H:%M:%S'),                                                      '%H:%M:%S')
+    day_start_time = datetime.datetime.strptime(day_start_time, '%H:%M:%S')
+    day_end_time = datetime.datetime.strptime(day_end_time, '%H:%M:%S')
+    diff = (current_utc_time - action_timestamp).total_seconds()
+
+    if diff < 0 and 24 - buffer_hours < action_timestamp.hour <= 24 and 0 <= current_utc_time.hour <= buffer_hours:
+        diff = (day_end_time - action_timestamp).total_seconds() + (
+                current_utc_time - day_start_time).total_seconds()
+
+    return 0 <= diff <= buffer_seconds

--- a/src/weekly_reminder.py
+++ b/src/weekly_reminder.py
@@ -1,83 +1,9 @@
 import json
-import boto3
-import os
 import smartsheet
-import re
-
-class oc_cluster:
-    def __init__(self, cluster_detail, ocm_account):
-        details = cluster_detail.split(' ')
-        details = [detail for detail in details if detail]
-        self.id = details[0]
-        self.name = details[1]
-        self.internal_name = details[1]
-        self.api_url = details[2]
-        self.ocp_version = details[3]
-        self.type = details[4]
-        self.hcp = details[5]
-        self.cloud_provider = details[6]
-        self.region = details[7]
-        self.status = details[8]
-        self.nodes = []
-        self.ocm_account = ocm_account
-        self.creation_date = ''
-        self.creator_name = ''
-        self.creator_email = ''
-
-def get_ipi_cluster_name(cluster:oc_cluster):
-    if cluster.name.count('-') == 4:
-        try:
-            url = run_command(f'ocm describe cluster {cluster.id} | grep "Console URL:"')
-            url = url.replace('Console URL:', '').strip()
-            result = re.search(r"^https:\/\/console-openshift-console.apps.(.*).ocp2.odhdev.com$", url)
-            if result:
-                cluster.internal_name = result.group(1)
-        except:
-            print(f'could not retrieve internal name for IPI cluster {cluster.name}, the cluster seems stale or non-existent')
-
-def get_all_cluster_details(ocm_account:str, clusters:list):
-    get_cluster_list(ocm_account)
-    clusters_details = open(f'clusters_{ocm_account}.txt').readlines()
-    for cluster_detail in clusters_details:
-        cluster = oc_cluster(cluster_detail, ocm_account)
-        if cluster.type == 'ocp':
-            get_ipi_cluster_name(cluster)
-        if cluster.cloud_provider == 'aws' and (
-                cluster.type != 'ocp' or (cluster.type == 'ocp' and cluster.name != cluster.internal_name)):
-            clusters.append(cluster)
-    # clusters = [cluster for cluster in clusters if cluster.cloud_provider == 'aws']
-    update_cluster_details(clusters)
+import utils
 
 
-def update_cluster_details(clusters:list[oc_cluster]):
-    for cluster in clusters:
-        run_command(f'script/./get_cluster_details.sh {cluster.ocm_account} {cluster.id}')
-        details = json.load(open(f'{cluster.id}_details.json'))
-        cluster.creation_date = details['creation_date']
-        cluster.creator_name = details['creator_name']
-        if details['creator_email'] and details['creator_email'] != 'null':
-            cluster.creator_email = details['creator_email']
-            if '+' in cluster.creator_email:
-                cluster.creator_email = get_original_email_address(cluster.creator_email)
-
-
-def get_original_email_address(email:str):
-    parts = email.split('@')
-    original_prefix = parts[0].split('+')[0]
-    return f'{original_prefix}@{parts[1]}'
-
-
-
-def get_cluster_list(ocm_account:str):
-    run_command(f'script/./get_all_cluster_details.sh {ocm_account}')
-
-def run_command(command):
-    output = os.popen(command).read()
-    # print(output)
-    return output
-
-
-def send_weekly_reminder(clusters:dict[oc_cluster]):
+def send_weekly_reminder(clusters:dict[utils.OcCluster]):
     column_map = {}
     smart = smartsheet.Smartsheet()
     # response = smart.Sheets.list_sheets()
@@ -85,7 +11,6 @@ def send_weekly_reminder(clusters:dict[oc_cluster]):
     sheet = smart.Sheets.get_sheet(sheed_id)
     for column in sheet.columns:
         column_map[column.title] = column.id
-    print(column_map)
 
     # process existing data
     existingClusterIds = [cluster.id for cluster in clusters]
@@ -107,16 +32,14 @@ def send_request_to_update_inactive_hours(row:smartsheet.smartsheet.models.row, 
     response = smart.Passthrough.post(f'/sheets/{sheed_id}/updaterequests', payload)
     # print(response)
 
+
 def main():
     clusters = []
     ocm_accounts = ['PROD', 'STAGE']
 
     for ocm_account in ocm_accounts:
-        get_all_cluster_details(ocm_account, clusters)
+        utils.get_all_cluster_details(ocm_account, clusters)
     send_weekly_reminder(clusters)
-
-
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Standardizes all hibernation functions into `hibernate_clusters.py`
- Standardizes all resume functions into `resume_clusters.py`
- Creates new `utils.py` file for all common functions called across the library
- Fixes a pervasive bug around identifying EC2 instances associated with a certain HCP clusters. This resolves the inability to hibernate and resume certain HCP clusters, and fix their erroneous accumulation of duplicate worker nodes.
- Removes Smartsheet update inefficiencies in the standalone Hibernate and Resume Cluster actions, which rapidly speeds up their execution
- Adds stdout flushes to all top-level print calls, for real-time logging